### PR TITLE
Add missing phpmailer dependency and add psalm config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "monolog/monolog"  : "2.0.2",
         "ext-json"         : "*",
         "ext-pdo"          : "*",
-        "ext-sodium"       : "*"
+        "ext-sodium"       : "*",
+        "phpmailer/phpmailer": "^6.1"
     },
     "require-dev"       : {
         "filp/whoops"                 : "2.7.1",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    errorLevel="8"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | maybe
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT

The code is relying on phpmailer but it was not included as a dependency. This change fixes that.

Also, I added the psalm config file, now you can get the vimeo/psalm phar file, add it in your $PATH and run `psalm` to see errors in the code found with static analysis ;)

Note also that the PR template refers to an inexisting CHANGELOG file!
