### PR TITLE
[CI] Override ext-openswoole platform in root-and-suggested so dependency updates run without the extension

### DIFF
--- a/.github/ci/root-and-suggested/composer.json
+++ b/.github/ci/root-and-suggested/composer.json
@@ -28,6 +28,9 @@
   "config"            : {
     "allow-plugins" : {
       "php-http/discovery" : true
+    },
+    "platform"      : {
+      "ext-openswoole" : "26.2.0"
     }
   }
 }

--- a/.github/ci/root-and-suggested/composer.lock
+++ b/.github/ci/root-and-suggested/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "639c44f775b2686f02eee74bc1d15b60",
+    "content-hash": "fc10128dfc1245d77395b2932506afce",
     "packages": [
         {
             "name": "psr/container",
@@ -4007,5 +4007,8 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "ext-openswoole": "26.2.0"
+    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
# Description

Fixes the nightly **Update Dependencies** workflow, which has been failing on
`26.x` since the runtime-entry fold ([#914](https://github.com/valkyrjaio/valkyrja-php/pull/914)).

The `Root and Suggested CI` step runs `composer update` in
`.github/ci/root-and-suggested`, which now has `openswoole/core` in its
`require-dev`. `openswoole/core` hard-requires `ext-openswoole`, and the
update-dependencies runner has no such C extension, so resolution fails:

```
- Root composer.json requires openswoole/core ^26.2.0 -> satisfiable by openswoole/core[26.2.0].
- openswoole/core 26.2.0 requires ext-openswoole >=26.2.0 -> it is missing from your system.
```

This adds a `config.platform` override pinning `ext-openswoole` to `26.2.0` in
that directory's `composer.json`, so every composer operation there (`update`,
`install`, `outdated`) treats the extension as present regardless of the runner.
It fixes all three `root-and-suggested-*` composer scripts at once and needs no
change to the pinned reusable update-dependencies workflow.

This is the documented, single-source mechanism for a dev-only dependency on an
extension that isn't present in every environment — preferable to sprinkling
`--ignore-platform-req=ext-openswoole` across individual scripts, which would
only cover the exact commands edited and miss any bare composer call the reusable
workflow makes. The jobs that actually run OpenSwoole code (PHPStan, Psalm,
PHPUnit) still provision the real extension, so their coverage of the entry
classes is unaffected. The framework itself still installs with no runtime
extension present.

## Types of changes

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] Improvement _(non-breaking change which improves code)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/ci/root-and-suggested/composer.json`** — added a `config.platform` override pinning `ext-openswoole` to `26.2.0` so composer resolves `openswoole/core` without the C extension installed.
- **`.github/ci/root-and-suggested/composer.lock`** — recorded the matching `platform-overrides` (no package version changes).
