### PR TITLE
[Application] Bridge the OpenSwoole request/response in the worker HTTP entry

### DIFF
--- a/src/Valkyrja/Application/Entry/OpenSwoole/OpenSwooleHttp.php
+++ b/src/Valkyrja/Application/Entry/OpenSwoole/OpenSwooleHttp.php
@@ -22,6 +22,15 @@ use Valkyrja\Application\Entry\Abstract\WorkerHttp;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Stream\Stream;
+use Valkyrja\Http\Middleware\Handler\Contract\SendingResponseHandlerContract;
+use Valkyrja\Http\Server\Handler\Contract\RequestHandlerContract;
+
+use function str_replace;
+use function strtoupper;
 
 class OpenSwooleHttp extends WorkerHttp
 {
@@ -76,10 +85,99 @@ class OpenSwooleHttp extends WorkerHttp
 
     /**
      * Handle a single Swoole request.
+     *
+     * Converts the OpenSwoole request into a framework request, dispatches it
+     * through an isolated child application, and writes the framework response
+     * back out through the OpenSwoole response.
      */
     public static function onRequest(ApplicationContract $app, ContainerData $data, Request $request, Response $response): void
     {
-        static::handle($app, $data, static::getRequest());
+        $serverRequest = static::getRequestFromSwooleRequest($request);
+
+        $frameworkResponse = static::handleSwooleRequest($app, $data, $serverRequest);
+
+        static::emitSwooleResponse($frameworkResponse, $response);
+    }
+
+    /**
+     * Get the framework server request from a given OpenSwoole request.
+     */
+    public static function getRequestFromSwooleRequest(Request $request): ServerRequestContract
+    {
+        $server = static::getServerParamsFromSwooleRequest($request);
+
+        /** @var array<array-key, mixed> $query */
+        $query = $request->get ?? [];
+        /** @var array<array-key, mixed> $body */
+        $body = $request->post ?? [];
+        /** @var array<string, string|null> $cookies */
+        $cookies = $request->cookie ?? [];
+        /** @var array<array-key, mixed> $files */
+        $files = $request->files ?? [];
+
+        $serverRequest = RequestFactory::fromGlobals(
+            server: $server,
+            query: $query,
+            body: $body,
+            cookies: $cookies,
+            files: $files,
+        );
+
+        $stream = new Stream();
+        $stream->write(static::getContentFromSwooleRequest($request));
+        $stream->rewind();
+
+        return $serverRequest
+            ->withBody($stream);
+    }
+
+    /**
+     * Handle a framework request through an isolated child application and
+     * return the resulting framework response.
+     *
+     * Mirrors the request handler's run() pipeline (handle, then the sending
+     * response middleware) but returns the response for the worker to emit
+     * instead of sending it through the PHP SAPI.
+     */
+    public static function handleSwooleRequest(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): ResponseContract
+    {
+        $childContainer = static::getChildContainer($app, $data);
+        $childApp       = static::getChildApplication($app, $childContainer);
+
+        static::bootstrapChildContainer($childApp, $childContainer);
+
+        $handler  = $childContainer->getSingleton(RequestHandlerContract::class);
+        $response = $handler->handle($request);
+
+        $sendingResponseHandler = $childContainer->getSingleton(SendingResponseHandlerContract::class);
+        $response               = $sendingResponseHandler->sendingResponse($request, $response);
+
+        $childContainer->setSingleton(ResponseContract::class, $response);
+
+        $handler->terminate($request, $response);
+
+        return $response;
+    }
+
+    /**
+     * Write a framework response back out through the OpenSwoole response.
+     */
+    public static function emitSwooleResponse(ResponseContract $response, Response $swooleResponse): void
+    {
+        static::sendSwooleStatus(
+            $swooleResponse,
+            $response->getStatusCode()->value,
+            $response->getReasonPhrase()
+        );
+
+        foreach ($response->getHeaders()->getAll() as $header) {
+            static::sendSwooleHeader($swooleResponse, $header->getName(), $header->getHeaderLine());
+        }
+
+        $body = $response->getBody();
+        $body->rewind();
+
+        static::sendSwooleBody($swooleResponse, $body->getContents());
     }
 
     /**
@@ -98,5 +196,84 @@ class OpenSwooleHttp extends WorkerHttp
     public static function startServer(Server $server): void
     {
         $server->start();
+    }
+
+    /**
+     * Marshal a $_SERVER-style params array from an OpenSwoole request.
+     *
+     * OpenSwoole exposes lowercase server keys (e.g. `request_uri`) and keeps
+     * request headers in a separate lowercase map, whereas the framework
+     * expects PHP's uppercase `$_SERVER` conventions with headers folded in as
+     * `HTTP_*` (and `CONTENT_TYPE`/`CONTENT_LENGTH`) entries.
+     *
+     * @return array<string, string|int|float|array<scalar>>
+     */
+    protected static function getServerParamsFromSwooleRequest(Request $request): array
+    {
+        $server = [];
+
+        /** @var array<array-key, string|int|float|array<scalar>> $swooleServer */
+        $swooleServer = $request->server ?? [];
+
+        foreach ($swooleServer as $key => $value) {
+            $server[strtoupper((string) $key)] = $value;
+        }
+
+        /** @var array<array-key, string> $swooleHeaders */
+        $swooleHeaders = $request->header ?? [];
+
+        foreach ($swooleHeaders as $name => $value) {
+            $normalizedName = strtoupper(str_replace('-', '_', (string) $name));
+
+            if ($normalizedName === 'CONTENT_TYPE' || $normalizedName === 'CONTENT_LENGTH') {
+                $server[$normalizedName] = $value;
+
+                continue;
+            }
+
+            $server['HTTP_' . $normalizedName] = $value;
+        }
+
+        return $server;
+    }
+
+    /**
+     * Get the raw request body content from an OpenSwoole request.
+     *
+     * @codeCoverageIgnore The raw content is only available for a live OpenSwoole request.
+     */
+    protected static function getContentFromSwooleRequest(Request $request): string
+    {
+        return (string) $request->rawContent();
+    }
+
+    /**
+     * Send the status line through the OpenSwoole response.
+     *
+     * @codeCoverageIgnore The OpenSwoole response is only writable for a live request.
+     */
+    protected static function sendSwooleStatus(Response $response, int $statusCode, string $reasonPhrase): void
+    {
+        $response->status($statusCode, $reasonPhrase);
+    }
+
+    /**
+     * Send a single header through the OpenSwoole response.
+     *
+     * @codeCoverageIgnore The OpenSwoole response is only writable for a live request.
+     */
+    protected static function sendSwooleHeader(Response $response, string $name, string $value): void
+    {
+        $response->header($name, $value);
+    }
+
+    /**
+     * Send the response body through the OpenSwoole response.
+     *
+     * @codeCoverageIgnore The OpenSwoole response is only writable for a live request.
+     */
+    protected static function sendSwooleBody(Response $response, string $body): void
+    {
+        $response->end($body);
     }
 }

--- a/tests/Tests/Fixtures/Application/Entry/OpenSwoole/OpenSwooleHttpFixture.php
+++ b/tests/Tests/Fixtures/Application/Entry/OpenSwoole/OpenSwooleHttpFixture.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Fixtures\Application\Entry\OpenSwoole;
 
+use OpenSwoole\Http\Request;
+use OpenSwoole\Http\Response;
 use OpenSwoole\Http\Server;
 use Override;
 use Valkyrja\Application\Data\Contract\HttpConfigContract;
@@ -21,31 +23,51 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\ContainerData;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
-use Valkyrja\Http\Message\Request\ServerRequest;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\Response as FrameworkResponse;
 
 /**
  * Testable OpenSwooleHttp subclass.
  *
- * Overrides the runtime seams so run() can be driven without the OpenSwoole
- * event loop: bootstrap() returns an injected application, handle() records
- * calls, and startServer() records that the (blocking) start was reached
- * instead of actually starting the server.
+ * Overrides the runtime seams so the entry can be driven without the OpenSwoole
+ * event loop or a live connection: bootstrap() returns an injected application,
+ * startServer() records that the (blocking) start was reached, handleSwooleRequest()
+ * returns an injected framework response, and the request/response I/O seams
+ * (rawContent()/status()/header()/end()) record their arguments instead of
+ * touching a non-live OpenSwoole request or response.
  */
 final class OpenSwooleHttpFixture extends OpenSwooleHttp
 {
     public static ApplicationContract $app;
 
-    public static int $handleCallCount = 0;
-
     public static bool $serverStarted = false;
+
+    public static int $handleSwooleRequestCallCount = 0;
+
+    public static ResponseContract $frameworkResponse;
+
+    public static string $rawContent = '';
+
+    /** @var array{statusCode: int, reasonPhrase: string}|null */
+    public static array|null $sentStatus = null;
+
+    /** @var list<array{name: string, value: string}> */
+    public static array $sentHeaders = [];
+
+    public static string|null $sentBody = null;
 
     /**
      * Reset all recorded state between tests.
      */
     public static function reset(): void
     {
-        self::$handleCallCount = 0;
-        self::$serverStarted   = false;
+        self::$serverStarted                = false;
+        self::$handleSwooleRequestCallCount = 0;
+        self::$frameworkResponse            = new FrameworkResponse();
+        self::$rawContent                   = '';
+        self::$sentStatus                   = null;
+        self::$sentHeaders                  = [];
+        self::$sentBody                     = null;
     }
 
     #[Override]
@@ -55,20 +77,46 @@ final class OpenSwooleHttpFixture extends OpenSwooleHttp
     }
 
     #[Override]
-    public static function handle(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): void
+    public static function handleSwooleRequest(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): ResponseContract
     {
-        self::$handleCallCount++;
-    }
+        self::$handleSwooleRequestCallCount++;
 
-    #[Override]
-    public static function getRequest(): ServerRequestContract
-    {
-        return new ServerRequest();
+        return self::$frameworkResponse;
     }
 
     #[Override]
     public static function startServer(Server $server): void
     {
         self::$serverStarted = true;
+    }
+
+    #[Override]
+    protected static function getContentFromSwooleRequest(Request $request): string
+    {
+        return self::$rawContent;
+    }
+
+    #[Override]
+    protected static function sendSwooleStatus(Response $response, int $statusCode, string $reasonPhrase): void
+    {
+        self::$sentStatus = [
+            'statusCode'   => $statusCode,
+            'reasonPhrase' => $reasonPhrase,
+        ];
+    }
+
+    #[Override]
+    protected static function sendSwooleHeader(Response $response, string $name, string $value): void
+    {
+        self::$sentHeaders[] = [
+            'name'  => $name,
+            'value' => $value,
+        ];
+    }
+
+    #[Override]
+    protected static function sendSwooleBody(Response $response, string $body): void
+    {
+        self::$sentBody = $body;
     }
 }

--- a/tests/Tests/Functional/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php
+++ b/tests/Tests/Functional/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Functional\Application\Entry\OpenSwoole;
+
+use Override;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Directory\Directory;
+use Valkyrja\Application\Entry\OpenSwoole\OpenSwooleHttp;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\TextResponse;
+use Valkyrja\Http\Routing\Collection\Contract\RouteCollectionContract;
+use Valkyrja\Http\Routing\Data\Route;
+use Valkyrja\Tests\Functional\Abstract\TestCase;
+
+use function extension_loaded;
+
+/**
+ * Test the OpenSwooleHttp entry point against a fully booted application.
+ */
+#[RunTestsInSeparateProcesses]
+final class OpenSwooleHttpTest extends TestCase
+{
+    private ApplicationContract $workerApp;
+
+    /**
+     * The route handler.
+     */
+    public static function handleRoute(): TextResponse
+    {
+        return new TextResponse('Swoole route');
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        if (! extension_loaded('openswoole')) {
+            self::markTestSkipped('The openswoole extension is not loaded.');
+        }
+
+        $this->workerApp = OpenSwooleHttp::bootstrap(new HttpConfig(dir: Directory::$basePath));
+
+        $collection = $this->workerApp->getContainer()->getSingleton(RouteCollectionContract::class);
+
+        $collection->add(
+            new Route(
+                path: '/swoole',
+                name: 'swoole',
+                handler: [self::class, 'handleRoute']
+            )
+        );
+    }
+
+    public function testHandleSwooleRequestDispatchesAndReturnsResponse(): void
+    {
+        $data = $this->workerApp->getContainer()->getData();
+
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'REQUEST_URI'    => '/swoole',
+                'REQUEST_METHOD' => 'GET',
+            ]
+        );
+
+        $response = OpenSwooleHttp::handleSwooleRequest($this->workerApp, $data, $request);
+
+        self::assertInstanceOf(ResponseContract::class, $response);
+        self::assertSame('Swoole route', (string) $response->getBody());
+    }
+}

--- a/tests/Tests/Unit/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php
+++ b/tests/Tests/Unit/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php
@@ -22,9 +22,14 @@ use Valkyrja\Application\Entry\OpenSwoole\OpenSwooleHttp;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\ContainerData;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Http\Message\Enum\RequestMethod;
+use Valkyrja\Http\Message\Enum\StatusCode;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\TextResponse;
 use Valkyrja\Tests\Fixtures\Application\Entry\OpenSwoole\OpenSwooleHttpFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
+use function array_column;
 use function extension_loaded;
 
 /**
@@ -65,13 +70,65 @@ final class OpenSwooleHttpTest extends TestCase
         self::assertInstanceOf(Server::class, OpenSwooleHttp::getSwooleServer());
     }
 
-    public function testGetRequestHandlerDispatchesToHandle(): void
+    public function testGetRequestHandlerConvertsHandlesAndEmits(): void
     {
+        OpenSwooleHttpFixture::$frameworkResponse = new TextResponse('Body', StatusCode::ACCEPTED);
+
         $handler = OpenSwooleHttpFixture::getRequestHandler(OpenSwooleHttpFixture::$app, new ContainerData());
 
         $handler(new Request(), new Response());
 
-        self::assertSame(1, OpenSwooleHttpFixture::$handleCallCount);
+        self::assertSame(1, OpenSwooleHttpFixture::$handleSwooleRequestCallCount);
+        self::assertSame(StatusCode::ACCEPTED->value, OpenSwooleHttpFixture::$sentStatus['statusCode'] ?? null);
+        self::assertSame('Body', OpenSwooleHttpFixture::$sentBody);
+    }
+
+    public function testGetRequestFromSwooleRequestBuildsServerRequest(): void
+    {
+        OpenSwooleHttpFixture::$rawContent = 'payload';
+
+        $swooleRequest         = new Request();
+        $swooleRequest->server = [
+            'request_method'  => 'POST',
+            'request_uri'     => '/users',
+            'query_string'    => 'page=2',
+            'server_protocol' => 'HTTP/1.1',
+        ];
+        $swooleRequest->header = [
+            'host'           => 'example.com',
+            'content-type'   => 'application/json',
+            'content-length' => '7',
+            'x-custom'       => 'val',
+        ];
+        $swooleRequest->get    = ['page' => '2'];
+        $swooleRequest->post   = ['name' => 'Jane'];
+        $swooleRequest->cookie = ['session' => 'abc'];
+
+        $request = OpenSwooleHttpFixture::getRequestFromSwooleRequest($swooleRequest);
+
+        self::assertInstanceOf(ServerRequestContract::class, $request);
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(RequestMethod::POST, $request->getMethod());
+        self::assertSame('/users', $request->getUri()->getPath());
+        self::assertSame('application/json', $request->getHeaders()->getHeaderLine('content-type'));
+        self::assertSame('val', $request->getHeaders()->getHeaderLine('x-custom'));
+        self::assertSame('example.com', $request->getHeaders()->getHeaderLine('host'));
+    }
+
+    public function testEmitSwooleResponseWritesStatusHeadersAndBody(): void
+    {
+        $response = new TextResponse('Hello Swoole', StatusCode::ACCEPTED);
+
+        OpenSwooleHttpFixture::emitSwooleResponse($response, new Response());
+
+        self::assertSame(StatusCode::ACCEPTED->value, OpenSwooleHttpFixture::$sentStatus['statusCode'] ?? null);
+        self::assertSame($response->getReasonPhrase(), OpenSwooleHttpFixture::$sentStatus['reasonPhrase'] ?? null);
+        self::assertSame('Hello Swoole', OpenSwooleHttpFixture::$sentBody);
+        self::assertNotSame([], OpenSwooleHttpFixture::$sentHeaders);
+
+        $headerNames = array_column(OpenSwooleHttpFixture::$sentHeaders, 'name');
+
+        self::assertContains('Content-Type', $headerNames);
     }
 
     public function testOnStartDoesNotThrow(): void


### PR DESCRIPTION
# Description

The OpenSwoole HTTP worker entry could not actually serve a live request.
`OpenSwooleHttp::onRequest()` ignored the OpenSwoole `$request`/`$response`
passed by the server — it rebuilt the request from
`RequestFactory::fromGlobals()` and never wrote the framework response back to
the Swoole `$response`. This was carried over verbatim from the old
`valkyrja/openswoole` repo when the worker entries were folded into the
framework.

This PR adds the request/response bridge so the worker converts the OpenSwoole
request into a framework request, dispatches it through an isolated child
application, and emits the framework response back out through the OpenSwoole
response — mirroring the existing RoadRunner request-wrapper pattern. All of the
work stays inside `OpenSwooleHttp`; the shared `WorkerHttp` abstract and the
sibling FrankenPHP/RoadRunner entries are untouched.

The field mapping matches OpenSwoole's own PSR bridge (`OpenSwoole\Core\Psr`):
lowercase `->server` keys plus the separate `->header` map are folded into PHP's
`$_SERVER` conventions (`HTTP_*`, `CONTENT_TYPE`/`CONTENT_LENGTH`), and the body
is taken from `rawContent()`. On the way out, the status line, each header
(Set-Cookie kept split), and the body are written to the Swoole response.

The four irreducible Swoole I/O calls (`rawContent`/`status`/`header`/`end`)
cannot run without a live connection, so each is wrapped in a one-line
overridable seam marked `@codeCoverageIgnore` — the same pattern already used for
`startServer()` — and the test fixture overrides those seams to drive every
branch. `OpenSwooleHttp` reaches 100% line and 100% branch coverage; the full
suite (4889 tests) stays at 100%.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Application/Entry/OpenSwoole/OpenSwooleHttp.php`** — `onRequest()` now converts the OpenSwoole request, dispatches it, and emits the framework response back through the OpenSwoole response. Added `getRequestFromSwooleRequest()`/`getServerParamsFromSwooleRequest()` (Swoole request → framework `ServerRequest`), `handleSwooleRequest()` (runs the handle + sending-response middleware pipeline and returns the `ResponseContract` instead of SAPI-emitting), and `emitSwooleResponse()` (framework `Response` → Swoole response). The single Swoole I/O calls are isolated in `getContentFromSwooleRequest()`/`sendSwooleStatus()`/`sendSwooleHeader()`/`sendSwooleBody()` seams marked `@codeCoverageIgnore`.
- **`tests/Tests/Fixtures/Application/Entry/OpenSwoole/OpenSwooleHttpFixture.php`** — overrides the runtime seams to record status/header/body and raw content, and stubs `handleSwooleRequest()`, so the entry can be driven without the event loop or a live connection.
- **`tests/Tests/Unit/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php`** — covers request conversion (server/header folding, body), response emission (status, headers, body), and the `onRequest` convert → handle → emit wiring.
- **`tests/Tests/Functional/Application/Entry/OpenSwoole/OpenSwooleHttpTest.php`** — boots a real application, registers a route, and asserts `handleSwooleRequest()` dispatches and returns the expected framework response.
