### PR TITLE
[Application] Write the framework response back to the RoadRunner worker

### DIFF
--- a/src/Valkyrja/Application/Entry/RoadRunner/RoadRunnerHttp.php
+++ b/src/Valkyrja/Application/Entry/RoadRunner/RoadRunnerHttp.php
@@ -20,9 +20,14 @@ use Spiral\RoadRunner\Worker;
 use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Entry\Abstract\WorkerHttp;
 use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Data\ContainerData;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Stream\Stream;
+use Valkyrja\Http\Middleware\Handler\Contract\SendingResponseHandlerContract;
+use Valkyrja\Http\Server\Handler\Contract\RequestHandlerContract;
 
 class RoadRunnerHttp extends WorkerHttp
 {
@@ -52,7 +57,9 @@ class RoadRunnerHttp extends WorkerHttp
 
             $request = static::getRequestFromRoadRunnerRequest($roadRunnerRequest);
 
-            static::handle($app, $data, $request);
+            $response = static::handleRoadRunnerRequest($app, $data, $request);
+
+            static::respondToWorker($worker, $response);
         }
     }
 
@@ -102,5 +109,81 @@ class RoadRunnerHttp extends WorkerHttp
 
         return $request
             ->withBody($stream);
+    }
+
+    /**
+     * Handle a framework request through an isolated child application and
+     * return the resulting framework response.
+     *
+     * Mirrors the request handler's run() pipeline (handle, then the sending
+     * response middleware) but returns the response for the worker to emit
+     * instead of sending it through the PHP SAPI.
+     */
+    public static function handleRoadRunnerRequest(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): ResponseContract
+    {
+        $childContainer = static::getChildContainer($app, $data);
+        $childApp       = static::getChildApplication($app, $childContainer);
+
+        static::bootstrapChildContainer($childApp, $childContainer);
+
+        $handler  = $childContainer->getSingleton(RequestHandlerContract::class);
+        $response = $handler->handle($request);
+
+        $sendingResponseHandler = $childContainer->getSingleton(SendingResponseHandlerContract::class);
+        $response               = $sendingResponseHandler->sendingResponse($request, $response);
+
+        $childContainer->setSingleton(ResponseContract::class, $response);
+
+        $handler->terminate($request, $response);
+
+        return $response;
+    }
+
+    /**
+     * Write a framework response back out through the RoadRunner worker.
+     */
+    public static function respondToWorker(HttpWorker $worker, ResponseContract $response): void
+    {
+        $body = $response->getBody();
+        $body->rewind();
+
+        static::sendRoadRunnerResponse(
+            $worker,
+            $response->getStatusCode()->value,
+            $body->getContents(),
+            static::getHeadersForRoadRunnerResponse($response)
+        );
+    }
+
+    /**
+     * Marshal the RoadRunner header map from a framework response.
+     *
+     * RoadRunner expects each header name mapped to a list of its values; each
+     * framework header (including a distinct Set-Cookie per cookie) contributes
+     * one value line under its name.
+     *
+     * @return array<string, list<string>>
+     */
+    protected static function getHeadersForRoadRunnerResponse(ResponseContract $response): array
+    {
+        $headers = [];
+
+        foreach ($response->getHeaders()->getAll() as $header) {
+            $headers[$header->getName()][] = $header->getHeaderLine();
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Send the framework response through the RoadRunner worker.
+     *
+     * @param array<string, list<string>> $headers
+     *
+     * @codeCoverageIgnore Requires the RoadRunner worker runtime and relay.
+     */
+    protected static function sendRoadRunnerResponse(HttpWorker $worker, int $statusCode, string $body, array $headers): void
+    {
+        $worker->respond($statusCode, $body, $headers);
     }
 }

--- a/tests/Tests/Fixtures/Application/Entry/RoadRunner/RoadRunnerHttpFixture.php
+++ b/tests/Tests/Fixtures/Application/Entry/RoadRunner/RoadRunnerHttpFixture.php
@@ -23,6 +23,8 @@ use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\ContainerData;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Http\Message\Request\ServerRequest;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\Response;
 
 /**
  * Testable RoadRunnerHttp subclass.
@@ -30,8 +32,10 @@ use Valkyrja\Http\Message\Request\ServerRequest;
  * Overrides the runtime seams so run()'s worker loop can be driven without the
  * RoadRunner relay: bootstrap() returns an injected application, getWorker()
  * returns an injected worker, waitForRequest() returns queued requests (null
- * ends the loop), getRequestFromRoadRunnerRequest() returns a stub request, and
- * handle() records calls.
+ * ends the loop), getRequestFromRoadRunnerRequest() returns a stub request,
+ * handleRoadRunnerRequest() returns an injected framework response, and
+ * sendRoadRunnerResponse() records the emitted status/body/headers instead of
+ * writing back to a non-live worker.
  */
 final class RoadRunnerHttpFixture extends RoadRunnerHttp
 {
@@ -39,7 +43,9 @@ final class RoadRunnerHttpFixture extends RoadRunnerHttp
 
     public static HttpWorker $worker;
 
-    public static int $handleCallCount = 0;
+    public static int $handleRoadRunnerRequestCallCount = 0;
+
+    public static ResponseContract $frameworkResponse;
 
     /** @var list<Request|null> */
     public static array $requests = [];
@@ -48,15 +54,26 @@ final class RoadRunnerHttpFixture extends RoadRunnerHttp
 
     public static int $getRequestFromRoadRunnerRequestCallCount = 0;
 
+    public static int|null $sentStatus = null;
+
+    public static string|null $sentBody = null;
+
+    /** @var array<string, list<string>> */
+    public static array $sentHeaders = [];
+
     /**
      * Reset all recorded state between tests.
      */
     public static function reset(): void
     {
-        self::$handleCallCount                          = 0;
+        self::$handleRoadRunnerRequestCallCount         = 0;
+        self::$frameworkResponse                        = new Response();
         self::$requests                                 = [];
         self::$waitForRequestCallCount                  = 0;
         self::$getRequestFromRoadRunnerRequestCallCount = 0;
+        self::$sentStatus                               = null;
+        self::$sentBody                                 = null;
+        self::$sentHeaders                              = [];
     }
 
     #[Override]
@@ -66,9 +83,11 @@ final class RoadRunnerHttpFixture extends RoadRunnerHttp
     }
 
     #[Override]
-    public static function handle(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): void
+    public static function handleRoadRunnerRequest(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): ResponseContract
     {
-        self::$handleCallCount++;
+        self::$handleRoadRunnerRequestCallCount++;
+
+        return self::$frameworkResponse;
     }
 
     #[Override]
@@ -91,5 +110,16 @@ final class RoadRunnerHttpFixture extends RoadRunnerHttp
         self::$getRequestFromRoadRunnerRequestCallCount++;
 
         return new ServerRequest();
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    #[Override]
+    protected static function sendRoadRunnerResponse(HttpWorker $worker, int $statusCode, string $body, array $headers): void
+    {
+        self::$sentStatus  = $statusCode;
+        self::$sentBody    = $body;
+        self::$sentHeaders = $headers;
     }
 }

--- a/tests/Tests/Functional/Application/Entry/RoadRunner/RoadRunnerHttpTest.php
+++ b/tests/Tests/Functional/Application/Entry/RoadRunner/RoadRunnerHttpTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Functional\Application\Entry\RoadRunner;
+
+use Override;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Directory\Directory;
+use Valkyrja\Application\Entry\RoadRunner\RoadRunnerHttp;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\TextResponse;
+use Valkyrja\Http\Routing\Collection\Contract\RouteCollectionContract;
+use Valkyrja\Http\Routing\Data\Route;
+use Valkyrja\Tests\Functional\Abstract\TestCase;
+
+/**
+ * Test the RoadRunnerHttp entry point against a fully booted application.
+ */
+#[RunTestsInSeparateProcesses]
+final class RoadRunnerHttpTest extends TestCase
+{
+    private ApplicationContract $workerApp;
+
+    /**
+     * The route handler.
+     */
+    public static function handleRoute(): TextResponse
+    {
+        return new TextResponse('RoadRunner route');
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->workerApp = RoadRunnerHttp::bootstrap(new HttpConfig(dir: Directory::$basePath));
+
+        $collection = $this->workerApp->getContainer()->getSingleton(RouteCollectionContract::class);
+
+        $collection->add(
+            new Route(
+                path: '/roadrunner',
+                name: 'roadrunner',
+                handler: [self::class, 'handleRoute']
+            )
+        );
+    }
+
+    public function testHandleRoadRunnerRequestDispatchesAndReturnsResponse(): void
+    {
+        $data = $this->workerApp->getContainer()->getData();
+
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'REQUEST_URI'    => '/roadrunner',
+                'REQUEST_METHOD' => 'GET',
+            ]
+        );
+
+        $response = RoadRunnerHttp::handleRoadRunnerRequest($this->workerApp, $data, $request);
+
+        self::assertInstanceOf(ResponseContract::class, $response);
+        self::assertSame('RoadRunner route', (string) $response->getBody());
+    }
+}

--- a/tests/Tests/Unit/Application/Entry/RoadRunner/RoadRunnerHttpTest.php
+++ b/tests/Tests/Unit/Application/Entry/RoadRunner/RoadRunnerHttpTest.php
@@ -21,7 +21,9 @@ use Valkyrja\Application\Entry\RoadRunner\RoadRunnerHttp;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\ContainerData;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\TextResponse;
 use Valkyrja\Tests\Fixtures\Application\Entry\RoadRunner\RoadRunnerHttpFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -50,9 +52,10 @@ final class RoadRunnerHttpTest extends TestCase
 
         RoadRunnerHttpFixture::run(new HttpConfig());
 
-        self::assertSame(2, RoadRunnerHttpFixture::$handleCallCount);
+        self::assertSame(2, RoadRunnerHttpFixture::$handleRoadRunnerRequestCallCount);
         self::assertSame(2, RoadRunnerHttpFixture::$getRequestFromRoadRunnerRequestCallCount);
         self::assertSame(3, RoadRunnerHttpFixture::$waitForRequestCallCount);
+        self::assertSame(StatusCode::OK->value, RoadRunnerHttpFixture::$sentStatus);
     }
 
     public function testRunStopsImmediatelyWhenFirstRequestIsNull(): void
@@ -61,8 +64,9 @@ final class RoadRunnerHttpTest extends TestCase
 
         RoadRunnerHttpFixture::run(new HttpConfig());
 
-        self::assertSame(0, RoadRunnerHttpFixture::$handleCallCount);
+        self::assertSame(0, RoadRunnerHttpFixture::$handleRoadRunnerRequestCallCount);
         self::assertSame(1, RoadRunnerHttpFixture::$waitForRequestCallCount);
+        self::assertNull(RoadRunnerHttpFixture::$sentStatus);
     }
 
     public function testGetRequestFromRoadRunnerRequestBuildsServerRequest(): void
@@ -77,5 +81,20 @@ final class RoadRunnerHttpTest extends TestCase
 
         self::assertInstanceOf(ServerRequestContract::class, $request);
         self::assertSame('payload', (string) $request->getBody());
+    }
+
+    public function testRespondToWorkerWritesStatusHeadersAndBody(): void
+    {
+        $response = new TextResponse('RR body', StatusCode::ACCEPTED);
+
+        RoadRunnerHttpFixture::respondToWorker(RoadRunnerHttpFixture::$worker, $response);
+
+        self::assertSame(StatusCode::ACCEPTED->value, RoadRunnerHttpFixture::$sentStatus);
+        self::assertSame('RR body', RoadRunnerHttpFixture::$sentBody);
+        self::assertArrayHasKey('Content-Type', RoadRunnerHttpFixture::$sentHeaders);
+        self::assertSame(
+            [$response->getHeaders()->getHeaderLine('Content-Type')],
+            RoadRunnerHttpFixture::$sentHeaders['Content-Type']
+        );
     }
 }


### PR DESCRIPTION
# Description

The RoadRunner HTTP worker entry never wrote its response back to the worker.
`RoadRunnerHttp::run()` converted the incoming RoadRunner request into a
framework request and dispatched it via the shared `WorkerHttp::handle()` path,
which emits through the PHP SAPI (`header()`/`echo`). RoadRunner workers do not
read the SAPI output — a response only reaches the client when it is handed back
to the worker via `HttpWorker::respond()` — so the dispatched response was
silently dropped and the worker could not actually serve a live request.

This is the same latent gap that was just fixed for the OpenSwoole worker entry
(valkyrjaio/valkyrja-php#919); this PR applies the mirror fix for RoadRunner.
`run()` now dispatches through an isolated child application, obtains the
framework `ResponseContract`, and writes it back to the worker via `respond()`
(status, body, and a name → list-of-values header map, keeping a distinct
Set-Cookie per cookie).

The single irreducible worker call (`HttpWorker::respond()`) cannot run without
the RoadRunner relay, so it is wrapped in a one-line overridable seam marked
`@codeCoverageIgnore` — the same pattern already used for `getWorker()` /
`waitForRequest()` — and the test fixture overrides that seam to record the
emitted status/body/headers. `RoadRunnerHttp` stays at 100% line and 100% branch
coverage; the full suite (4888 tests) stays at 100%.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Application/Entry/RoadRunner/RoadRunnerHttp.php`** — `run()` now calls `handleRoadRunnerRequest()` (runs the handle + sending-response middleware pipeline and returns the `ResponseContract` instead of SAPI-emitting) and `respondToWorker()`, which builds the status/body/header map via `getHeadersForRoadRunnerResponse()` and writes it back through the `sendRoadRunnerResponse()` seam (`HttpWorker::respond()`, marked `@codeCoverageIgnore`).
- **`tests/Tests/Fixtures/Application/Entry/RoadRunner/RoadRunnerHttpFixture.php`** — replaces the old `handle()` override with `handleRoadRunnerRequest()` (returns an injected response) and overrides `sendRoadRunnerResponse()` to record the emitted status/body/headers, so the worker loop runs without the relay.
- **`tests/Tests/Unit/Application/Entry/RoadRunner/RoadRunnerHttpTest.php`** — asserts the loop dispatches and responds per request (and does neither when the first request is null), plus a case covering `respondToWorker()` status/headers/body marshaling.
- **`tests/Tests/Functional/Application/Entry/RoadRunner/RoadRunnerHttpTest.php`** — boots a real application, registers a route, and asserts `handleRoadRunnerRequest()` dispatches and returns the expected framework response.
