### PR TITLE
[Http] Replace stale terminable-middleware comment on RequestHandler::terminate

### DIFF
--- a/src/Valkyrja/Http/Server/Handler/RequestHandler.php
+++ b/src/Valkyrja/Http/Server/Handler/RequestHandler.php
@@ -106,7 +106,7 @@ class RequestHandler implements RequestHandlerContract
     #[Override]
     public function terminate(ServerRequestContract $request, ResponseContract $response): void
     {
-        // Dispatch the terminable middleware
+        // Dispatch the response sent middleware
         $this->responseSentHandler->responseSent($request, $response);
     }
 


### PR DESCRIPTION
# Description

Follow-up cleanup to #910, which renamed the terminal HTTP middleware stage
`Terminated` → `ResponseSent` (type, contract, handler, and method) but left one
stale inline comment behind. `RequestHandler::terminate()` still described its
dispatch as "the terminable middleware," even though it now dispatches the
`ResponseSent` middleware via `$this->responseSentHandler->responseSent(...)`.

This updates that single comment to match the post-#910 vocabulary, mirroring the
CLI side (`InputHandler::exit()` already reads `// Dispatch the process exiting
middleware`). The `terminate()` method name itself is intentionally kept — the
handler lifecycle methods (`handle`/`send`/`terminate`/`run`) are imperative verbs
and were never meant to mirror the stage names, so no behavior or signature
changes here.

A framework-wide sweep confirmed this was the only remaining `terminable` /
"terminated middleware" straggler across PHP, Java, and TypeScript — hence a
PHP-only, comment-only change.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Http/Server/Handler/RequestHandler.php`** — replaced the stale
  `// Dispatch the terminable middleware` comment in `terminate()` with
  `// Dispatch the response sent middleware`, aligning it with the `ResponseSent`
  stage naming introduced in #910 and the parallel CLI `InputHandler::exit()`
  comment. No logic change.
