### PR TITLE
[Http] Add routing path/regex/parameter combination tests

### DIFF
--- a/tests/Tests/Fixtures/Http/Routing/Controller/RoutingCombinationsControllerFixture.php
+++ b/tests/Tests/Fixtures/Http/Routing/Controller/RoutingCombinationsControllerFixture.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Http\Routing\Controller;
+
+use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Message\Response\Response;
+use Valkyrja\Http\Routing\Attribute\DynamicRoute;
+use Valkyrja\Http\Routing\Attribute\Parameter;
+use Valkyrja\Http\Routing\Constant\Regex;
+
+/**
+ * Controller fixture exercising a matrix of attribute-defined dynamic routes so the
+ * attribute construction path can be asserted to produce the same regex as direct
+ * construction.
+ */
+final class RoutingCombinationsControllerFixture
+{
+    /** @var non-empty-string */
+    public const string NUM_PATH   = '/num/{id}';
+    /** @var non-empty-string */
+    public const string NUM_NAME   = 'combinations.num';
+    /** @var non-empty-string */
+    public const string NUM_REGEX  = '/^\/num\/(?<id>\d+)$/';
+
+    /** @var non-empty-string */
+    public const string SLUG_PATH  = '/slug/{slug}';
+    /** @var non-empty-string */
+    public const string SLUG_NAME  = 'combinations.slug';
+    /** @var non-empty-string */
+    public const string SLUG_REGEX = '/^\/slug\/(?<slug>[a-zA-Z0-9-]+)$/';
+
+    /** @var non-empty-string */
+    public const string OPTIONAL_PATH  = '/optional/{opt?}';
+    /** @var non-empty-string */
+    public const string OPTIONAL_NAME  = 'combinations.optional';
+    /** @var non-empty-string */
+    public const string OPTIONAL_REGEX = '/^\/optional(?:\/)?(?<opt>[a-zA-Z]+)?$/';
+
+    /** @var non-empty-string */
+    public const string NON_CAPTURE_PATH  = '/nc/{nc}';
+    /** @var non-empty-string */
+    public const string NON_CAPTURE_NAME  = 'combinations.non-capture';
+    /** @var non-empty-string */
+    public const string NON_CAPTURE_REGEX = '/^\/nc\/(?:[a-zA-Z]+)$/';
+
+    /** @var non-empty-string */
+    public const string MULTI_PATH  = '/multi/{x}/{y}';
+    /** @var non-empty-string */
+    public const string MULTI_NAME  = 'combinations.multi';
+    /** @var non-empty-string */
+    public const string MULTI_REGEX = '/^\/multi\/(?<x>\d+)\/(?<y>[a-zA-Z]+)$/';
+
+    #[DynamicRoute(
+        path: self::NUM_PATH,
+        name: self::NUM_NAME,
+        parameters: [
+            new Parameter(name: 'id', regex: Regex::NUM),
+        ]
+    )]
+    public function num(): ResponseContract
+    {
+        return Response::create('num');
+    }
+
+    #[DynamicRoute(
+        path: self::SLUG_PATH,
+        name: self::SLUG_NAME,
+        parameters: [
+            new Parameter(name: 'slug', regex: Regex::SLUG),
+        ]
+    )]
+    public function slug(): ResponseContract
+    {
+        return Response::create('slug');
+    }
+
+    #[DynamicRoute(
+        path: self::OPTIONAL_PATH,
+        name: self::OPTIONAL_NAME,
+        parameters: [
+            new Parameter(name: 'opt', regex: Regex::ALPHA, isOptional: true),
+        ]
+    )]
+    public function optional(): ResponseContract
+    {
+        return Response::create('optional');
+    }
+
+    #[DynamicRoute(
+        path: self::NON_CAPTURE_PATH,
+        name: self::NON_CAPTURE_NAME,
+        parameters: [
+            new Parameter(name: 'nc', regex: Regex::ALPHA, shouldCapture: false),
+        ]
+    )]
+    public function nonCapture(): ResponseContract
+    {
+        return Response::create('nonCapture');
+    }
+
+    #[DynamicRoute(
+        path: self::MULTI_PATH,
+        name: self::MULTI_NAME,
+        parameters: [
+            new Parameter(name: 'x', regex: Regex::NUM),
+            new Parameter(name: 'y', regex: Regex::ALPHA),
+        ]
+    )]
+    public function multi(): ResponseContract
+    {
+        return Response::create('multi');
+    }
+}

--- a/tests/Tests/Unit/Http/Routing/Collector/AttributeRouteCollectorTest.php
+++ b/tests/Tests/Unit/Http/Routing/Collector/AttributeRouteCollectorTest.php
@@ -25,6 +25,7 @@ use Valkyrja\Tests\Fixtures\Http\Middleware\ThrowableCaughtMiddlewareFixture;
 use Valkyrja\Tests\Fixtures\Http\Routing\Controller\ControllerAttributedFixture;
 use Valkyrja\Tests\Fixtures\Http\Routing\Controller\ControllerFixture;
 use Valkyrja\Tests\Fixtures\Http\Routing\Controller\ControllerWithAllMiddlewareFixture;
+use Valkyrja\Tests\Fixtures\Http\Routing\Controller\RoutingCombinationsControllerFixture;
 use Valkyrja\Tests\Fixtures\Http\Routing\Provider\RouteProviderFixture;
 use Valkyrja\Tests\Fixtures\Http\Struct\IndexedJsonRequestStructEnum;
 use Valkyrja\Tests\Fixtures\Http\Struct\ResponseStructEnum;
@@ -135,5 +136,42 @@ final class AttributeRouteCollectorTest extends TestCase
         self::assertSame([AllMiddlewareFixture::class], $dynamicRoute->getThrowableCaughtMiddleware());
         self::assertSame(IndexedJsonRequestStructEnum::first, $dynamicRoute->getRequestStruct());
         self::assertSame(ResponseStructEnum::first, $dynamicRoute->getResponseStruct());
+    }
+
+    /**
+     * The attribute construction path must produce the same regex, across a matrix of
+     * parameter types and modifiers, as direct construction does through the Processor.
+     *
+     * @throws ReflectionException
+     */
+    public function testGetRoutesProducesExpectedRegexForCombinations(): void
+    {
+        $routes = new AttributeRouteCollector()->getRoutes(RoutingCombinationsControllerFixture::class);
+
+        $byName = [];
+
+        foreach ($routes as $route) {
+            $byName[$route->getName()] = $route;
+        }
+
+        $expected = [
+            RoutingCombinationsControllerFixture::NUM_NAME         => [RoutingCombinationsControllerFixture::NUM_PATH, RoutingCombinationsControllerFixture::NUM_REGEX],
+            RoutingCombinationsControllerFixture::SLUG_NAME        => [RoutingCombinationsControllerFixture::SLUG_PATH, RoutingCombinationsControllerFixture::SLUG_REGEX],
+            RoutingCombinationsControllerFixture::OPTIONAL_NAME    => [RoutingCombinationsControllerFixture::OPTIONAL_PATH, RoutingCombinationsControllerFixture::OPTIONAL_REGEX],
+            RoutingCombinationsControllerFixture::NON_CAPTURE_NAME => [RoutingCombinationsControllerFixture::NON_CAPTURE_PATH, RoutingCombinationsControllerFixture::NON_CAPTURE_REGEX],
+            RoutingCombinationsControllerFixture::MULTI_NAME       => [RoutingCombinationsControllerFixture::MULTI_PATH, RoutingCombinationsControllerFixture::MULTI_REGEX],
+        ];
+
+        self::assertCount(5, $routes);
+
+        foreach ($expected as $name => [$path, $regex]) {
+            self::assertArrayHasKey($name, $byName);
+
+            $route = $byName[$name];
+
+            self::assertInstanceOf(DynamicRouteContract::class, $route);
+            self::assertSame($path, $route->getPath());
+            self::assertSame($regex, $route->getRegex());
+        }
     }
 }

--- a/tests/Tests/Unit/Http/Routing/Matcher/MatcherTest.php
+++ b/tests/Tests/Unit/Http/Routing/Matcher/MatcherTest.php
@@ -14,14 +14,17 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Routing\Matcher;
 
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Valkyrja\Http\Message\Enum\RequestMethod;
 use Valkyrja\Http\Routing\Collection\RouteCollection;
 use Valkyrja\Http\Routing\Constant\Regex;
 use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\DynamicRoute;
 use Valkyrja\Http\Routing\Data\Parameter;
 use Valkyrja\Http\Routing\Data\Route;
 use Valkyrja\Http\Routing\Matcher\Matcher;
+use Valkyrja\Http\Routing\Processor\Processor;
 use Valkyrja\Http\Routing\Throwable\Exception\HttpRoutingInvalidRoutePathException;
 use Valkyrja\Tests\Fixtures\Http\Routing\Provider\RouteProviderFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -58,6 +61,27 @@ final class MatcherTest extends TestCase
     protected const string INVALID_DYNAMIC_REGEX      = '/^\/invalid\/(?<invalid>[a-zA-Z]+)$/';
 
     protected Matcher $matcher;
+
+    /**
+     * @return array<non-empty-string, array{non-empty-string, non-empty-string, non-empty-string|null}>
+     */
+    public static function matchingTypeProvider(): array
+    {
+        return [
+            'num'                  => [Regex::NUM, '123', 'abc'],
+            'alpha'                => [Regex::ALPHA, 'abc', 'abc1'],
+            'alpha lowercase'      => [Regex::ALPHA_LOWERCASE, 'abc', 'Abc'],
+            'alpha uppercase'      => [Regex::ALPHA_UPPERCASE, 'ABC', 'abc'],
+            'alpha num'            => [Regex::ALPHA_NUM, 'abc123', 'abc-1'],
+            'alpha num underscore' => [Regex::ALPHA_NUM_UNDERSCORE, 'abc_123', 'abc-1'],
+            'slug'                 => [Regex::SLUG, 'My-slug-1', 'has_underscore'],
+            'any'                  => [Regex::ANY, 'anything-1.x', null],
+            'uuid'                 => [Regex::UUID, '66a39476-b630-4b95-8bfb-355f3d4843c5', 'not-a-uuid'],
+            'uuid v4'              => [Regex::UUID_V4, '78cbd961-d07b-4ef9-89a7-b4ec9d1a70f0', '11111111-1111-1111-1111-111111111111'],
+            'ulid'                 => [Regex::ULID, '01KYGBV64MKWPK63CC1QH0VGF7', 'notaulid'],
+            'vlid v4'              => [Regex::VLID_V4, '04YHJMN6F5XHM497ZW', 'notavlid'],
+        ];
+    }
 
     #[Override]
     protected function setUp(): void
@@ -285,5 +309,200 @@ final class MatcherTest extends TestCase
         $matcher = $this->matcher;
 
         $matcher->match($dynamicPath, RequestMethod::ANY);
+    }
+
+    /**
+     * Each parameter regex type matches a valid value (and binds it) and rejects an invalid one.
+     *
+     * @param non-empty-string      $typeRegex
+     * @param non-empty-string      $validValue
+     * @param non-empty-string|null $invalidValue null when the type matches anything (ANY)
+     */
+    #[DataProvider('matchingTypeProvider')]
+    public function testDynamicRouteTypeMatchesValidAndRejectsInvalid(string $typeRegex, string $validValue, string|null $invalidValue): void
+    {
+        $matcher = $this->matcherFor(
+            $this->processedDynamicRoute('/{value}', 'typed', [new Parameter(name: 'value', regex: $typeRegex)])
+        );
+
+        $matched = $matcher->match("/$validValue", RequestMethod::ANY);
+
+        self::assertInstanceOf(DynamicRouteContract::class, $matched);
+        self::assertSame($validValue, $matched->getParameter('value')->getValue());
+
+        if ($invalidValue !== null) {
+            self::assertNull($matcher->match("/$invalidValue", RequestMethod::ANY));
+        }
+    }
+
+    /**
+     * A dynamic route restricted to GET is matched under GET and ANY, but not POST.
+     */
+    public function testRequestMethodFilteringForDynamicRoute(): void
+    {
+        $matcher = $this->matcherFor(
+            $this->processedDynamicRoute(
+                '/{name}',
+                'get-only-dynamic',
+                [new Parameter(name: 'name', regex: Regex::ALPHA)],
+                [RequestMethod::GET]
+            )
+        );
+
+        self::assertInstanceOf(DynamicRouteContract::class, $matcher->match('/foo', RequestMethod::GET));
+        self::assertInstanceOf(DynamicRouteContract::class, $matcher->match('/foo', RequestMethod::ANY));
+        self::assertNull($matcher->match('/foo', RequestMethod::POST));
+    }
+
+    /**
+     * A static route restricted to GET is matched under GET but not POST.
+     */
+    public function testRequestMethodFilteringForStaticRoute(): void
+    {
+        $matcher = $this->matcherFor(
+            new Route(
+                path: '/only-get',
+                name: 'get-only-static',
+                handler: [RouteProviderFixture::class, 'handler'],
+                requestMethods: [RequestMethod::GET]
+            )
+        );
+
+        $matched = $matcher->match('/only-get', RequestMethod::GET);
+
+        self::assertNotNull($matched);
+        self::assertNotInstanceOf(DynamicRouteContract::class, $matched);
+        self::assertNull($matcher->match('/only-get', RequestMethod::POST));
+    }
+
+    /**
+     * A trailing slash on the request path is normalized before matching.
+     */
+    public function testTrailingSlashIsNormalizedForMatching(): void
+    {
+        $matcher = $this->matcherFor(
+            new Route(
+                path: '/foo',
+                name: 'foo-static',
+                handler: [RouteProviderFixture::class, 'handler'],
+                requestMethods: [RequestMethod::ANY]
+            ),
+            $this->processedDynamicRoute('/bar/{x}', 'bar-dynamic', [new Parameter(name: 'x', regex: Regex::ALPHA)])
+        );
+
+        self::assertNotNull($matcher->match('/foo/', RequestMethod::ANY));
+        self::assertInstanceOf(DynamicRouteContract::class, $matcher->match('/bar/abc/', RequestMethod::ANY));
+    }
+
+    /**
+     * A static route wins over a dynamic route that would also match the same path.
+     */
+    public function testStaticRouteTakesPrecedenceOverDynamic(): void
+    {
+        $matcher = $this->matcherFor(
+            new Route(
+                path: '/users',
+                name: 'static-users',
+                handler: [RouteProviderFixture::class, 'handler'],
+                requestMethods: [RequestMethod::ANY]
+            ),
+            $this->processedDynamicRoute('/{name}', 'any-name', [new Parameter(name: 'name', regex: Regex::ALPHA)])
+        );
+
+        $static = $matcher->match('/users', RequestMethod::ANY);
+
+        self::assertNotNull($static);
+        self::assertNotInstanceOf(DynamicRouteContract::class, $static);
+
+        // A path with no static route still falls through to the dynamic route.
+        self::assertInstanceOf(DynamicRouteContract::class, $matcher->match('/other', RequestMethod::ANY));
+    }
+
+    /**
+     * Multiple parameters are each extracted and bound to their own values.
+     */
+    public function testMultipleParametersAreExtracted(): void
+    {
+        $matcher = $this->matcherFor(
+            $this->processedDynamicRoute(
+                '/a/{x}/b/{y}',
+                'multi',
+                [
+                    new Parameter(name: 'x', regex: Regex::NUM),
+                    new Parameter(name: 'y', regex: Regex::ALPHA),
+                ]
+            )
+        );
+
+        $matched = $matcher->match('/a/12/b/two', RequestMethod::ANY);
+
+        self::assertInstanceOf(DynamicRouteContract::class, $matched);
+        self::assertSame('12', $matched->getParameter('x')->getValue());
+        self::assertSame('two', $matched->getParameter('y')->getValue());
+    }
+
+    /**
+     * A non-capturing parameter still matches but is not bound to a value.
+     */
+    public function testNonCaptureParameterIsNotBound(): void
+    {
+        $matcher = $this->matcherFor(
+            $this->processedDynamicRoute(
+                '/{nc}',
+                'non-capture',
+                [new Parameter(name: 'nc', regex: Regex::ALPHA, shouldCapture: false)]
+            )
+        );
+
+        $matched = $matcher->match('/abc', RequestMethod::ANY);
+
+        self::assertInstanceOf(DynamicRouteContract::class, $matched);
+        self::assertNull($matched->getParameter('nc')->getValue());
+    }
+
+    /**
+     * Build a dynamic route with its regex produced by the Processor (the real pipeline).
+     *
+     * @param non-empty-string $path
+     * @param non-empty-string $name
+     * @param array<Parameter> $parameters
+     * @param RequestMethod[]  $requestMethods
+     *
+     * @throws HttpRoutingInvalidRoutePathException
+     */
+    private function processedDynamicRoute(
+        string $path,
+        string $name,
+        array $parameters,
+        array $requestMethods = [RequestMethod::ANY]
+    ): DynamicRouteContract {
+        $route = new DynamicRoute(
+            path: $path,
+            name: $name,
+            regex: '',
+            parameters: $parameters,
+            handler: [RouteProviderFixture::class, 'handler'],
+            requestMethods: $requestMethods
+        );
+
+        $processed = new Processor()->route($route);
+
+        self::assertInstanceOf(DynamicRouteContract::class, $processed);
+
+        return $processed;
+    }
+
+    /**
+     * Build a matcher backed by a collection of the given routes.
+     */
+    private function matcherFor(RouteContract ...$routes): Matcher
+    {
+        $collection = new RouteCollection();
+
+        foreach ($routes as $route) {
+            $collection->add($route);
+        }
+
+        return new Matcher(collection: $collection);
     }
 }

--- a/tests/Tests/Unit/Http/Routing/Processor/ProcessorTest.php
+++ b/tests/Tests/Unit/Http/Routing/Processor/ProcessorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Processor;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Valkyrja\Http\Routing\Constant\Regex;
 use Valkyrja\Http\Routing\Data\DynamicRoute;
 use Valkyrja\Http\Routing\Data\Parameter;
@@ -21,11 +22,136 @@ use Valkyrja\Http\Routing\Processor\Processor;
 use Valkyrja\Http\Routing\Throwable\Exception\HttpRoutingInvalidRoutePathException;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
+use function preg_match;
+
 /**
  * Class ProcessorTest.
  */
 final class ProcessorTest extends TestCase
 {
+    /**
+     * @return array<non-empty-string, array{non-empty-string}>
+     */
+    public static function parameterTypeProvider(): array
+    {
+        return [
+            'num'                  => [Regex::NUM],
+            'id'                   => [Regex::ID],
+            'slug'                 => [Regex::SLUG],
+            'any'                  => [Regex::ANY],
+            'alpha'                => [Regex::ALPHA],
+            'alpha lowercase'      => [Regex::ALPHA_LOWERCASE],
+            'alpha uppercase'      => [Regex::ALPHA_UPPERCASE],
+            'alpha num'            => [Regex::ALPHA_NUM],
+            'alpha num underscore' => [Regex::ALPHA_NUM_UNDERSCORE],
+            'uuid'                 => [Regex::UUID],
+            'uuid v1'              => [Regex::UUID_V1],
+            'uuid v3'              => [Regex::UUID_V3],
+            'uuid v4'              => [Regex::UUID_V4],
+            'uuid v5'              => [Regex::UUID_V5],
+            'uuid v6'              => [Regex::UUID_V6],
+            'uuid v7'              => [Regex::UUID_V7],
+            'uuid v8'              => [Regex::UUID_V8],
+            'ulid'                 => [Regex::ULID],
+            'vlid'                 => [Regex::VLID],
+            'vlid v1'              => [Regex::VLID_V1],
+            'vlid v2'              => [Regex::VLID_V2],
+            'vlid v3'              => [Regex::VLID_V3],
+            'vlid v4'              => [Regex::VLID_V4],
+        ];
+    }
+
+    /**
+     * @return array<non-empty-string, array{non-empty-string, array<array{non-empty-string, non-empty-string, bool, bool}>, non-empty-string}>
+     */
+    public static function structuralProvider(): array
+    {
+        return [
+            'parameter at end'          => [
+                '/parameters/{name}',
+                [['name', Regex::ALPHA, false, true]],
+                '/^\/parameters\/(?<name>[a-zA-Z]+)$/',
+            ],
+            'parameter at start'        => [
+                '/{name}/edit',
+                [['name', Regex::ALPHA, false, true]],
+                '/^\/(?<name>[a-zA-Z]+)\/edit$/',
+            ],
+            'parameter in middle'       => [
+                '/user/{id}/edit',
+                [['id', Regex::NUM, false, true]],
+                '/^\/user\/(?<id>\d+)\/edit$/',
+            ],
+            'multiple separated params' => [
+                '/a/{x}/b/{y}',
+                [['x', Regex::NUM, false, true], ['y', Regex::ALPHA, false, true]],
+                '/^\/a\/(?<x>\d+)\/b\/(?<y>[a-zA-Z]+)$/',
+            ],
+            'adjacent params'           => [
+                '/{x}{y}',
+                [['x', Regex::NUM, false, true], ['y', Regex::ALPHA, false, true]],
+                '/^\/(?<x>\d+)(?<y>[a-zA-Z]+)$/',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<non-empty-string, array{non-empty-string, array<array{non-empty-string, non-empty-string, bool, bool}>, non-empty-string}>
+     */
+    public static function modifierProvider(): array
+    {
+        return [
+            'single optional'          => [
+                '/{opt?}',
+                [['opt', Regex::ALPHA, true, true]],
+                '/^(?:\/)?(?<opt>[a-zA-Z]+)?$/',
+            ],
+            'non-capture'              => [
+                '/{nc}',
+                [['nc', Regex::ALPHA, false, false]],
+                '/^\/(?:[a-zA-Z]+)$/',
+            ],
+            'optional non-capture'     => [
+                '/{onc?}',
+                [['onc', Regex::ALPHA, true, false]],
+                '/^(?:\/)?(?:[a-zA-Z]+)?$/',
+            ],
+            'multiple optionals'       => [
+                '/{a?}/{b?}',
+                [['a', Regex::ALPHA, true, true], ['b', Regex::ALPHA, true, true]],
+                '/^(?:\/)?(?<a>[a-zA-Z]+)?(?:\/)?(?<b>[a-zA-Z]+)?$/',
+            ],
+            'mixed capture/no-capture' => [
+                '/{cap}/{nc}',
+                [['cap', Regex::ALPHA, false, true], ['nc', Regex::NUM, false, false]],
+                '/^\/(?<cap>[a-zA-Z]+)\/(?:\d+)$/',
+            ],
+        ];
+    }
+
+    /**
+     * Build parameters from compact specs: [name, regex, isOptional, shouldCapture].
+     *
+     * @param array<array{non-empty-string, non-empty-string, bool, bool}> $parameterSpecs
+     *
+     * @return array<Parameter>
+     */
+    private static function buildParameters(array $parameterSpecs): array
+    {
+        $parameters = [];
+
+        foreach ($parameterSpecs as [$name, $regex, $isOptional, $shouldCapture]) {
+            $parameters[] = new Parameter(
+                name: $name,
+                regex: $regex,
+                isOptional: $isOptional,
+                shouldCapture: $shouldCapture,
+            );
+        }
+
+        return $parameters;
+    }
+
     public function testStaticRoute(): void
     {
         $processor = new Processor();
@@ -177,5 +303,143 @@ final class ProcessorTest extends TestCase
         self::assertSame($route->getPath(), $routeAfterProcessing->getPath());
         self::assertSame($route->getName(), $routeAfterProcessing->getName());
         self::assertSame('/^\/(?:[a-zA-Z]+)$/', $routeAfterProcessing->getRegex());
+    }
+
+    /**
+     * Every parameter regex type flows through unchanged, wrapped in a named capture group,
+     * and the produced regex is valid PCRE.
+     *
+     * @param non-empty-string $typeRegex
+     */
+    #[DataProvider('parameterTypeProvider')]
+    public function testCapturingParameterTypeProducesExpectedRegex(string $typeRegex): void
+    {
+        $regex = $this->processRegex(
+            path: '/{id}',
+            parameters: [new Parameter(name: 'id', regex: $typeRegex)],
+        );
+
+        self::assertSame('/^\/(?<id>' . $typeRegex . ')$/', $regex);
+        // The produced regex must be a syntactically valid PCRE (no escaping/delimiter issues).
+        self::assertNotFalse(@preg_match($regex, ''));
+    }
+
+    /**
+     * Structural combinations: parameter position, multiple/adjacent parameters, static mixes.
+     *
+     * @param non-empty-string                                             $path
+     * @param array<array{non-empty-string, non-empty-string, bool, bool}> $parameterSpecs
+     * @param non-empty-string                                             $expected
+     */
+    #[DataProvider('structuralProvider')]
+    public function testStructuralCombinationProducesExpectedRegex(string $path, array $parameterSpecs, string $expected): void
+    {
+        $regex = $this->processRegex(
+            path: $path,
+            parameters: self::buildParameters($parameterSpecs),
+        );
+
+        self::assertSame($expected, $regex);
+        self::assertNotFalse(@preg_match($regex, ''));
+    }
+
+    /**
+     * Modifier combinations: optional, non-capture, and their mixes.
+     *
+     * @param non-empty-string                                             $path
+     * @param array<array{non-empty-string, non-empty-string, bool, bool}> $parameterSpecs
+     * @param non-empty-string                                             $expected
+     */
+    #[DataProvider('modifierProvider')]
+    public function testModifierCombinationProducesExpectedRegex(string $path, array $parameterSpecs, string $expected): void
+    {
+        $regex = $this->processRegex(
+            path: $path,
+            parameters: self::buildParameters($parameterSpecs),
+        );
+
+        self::assertSame($expected, $regex);
+        self::assertNotFalse(@preg_match($regex, ''));
+    }
+
+    /**
+     * A path marking a parameter optional via `{name?}` flips a non-optional parameter to
+     * optional when building the regex (the `str_contains($regex, name . '?')` branch).
+     */
+    public function testPathQuestionMarkForcesOptionalRegex(): void
+    {
+        $regex = $this->processRegex(
+            path: '/{opt?}',
+            // Constructed as NOT optional; the '?' in the path must still make the regex optional.
+            parameters: [new Parameter(name: 'opt', regex: Regex::ALPHA, isOptional: false)],
+        );
+
+        self::assertSame('/^(?:\/)?(?<opt>[a-zA-Z]+)?$/', $regex);
+    }
+
+    /**
+     * A dynamic route whose path has no `{` placeholder is left untouched (no regex built).
+     */
+    public function testDynamicRouteWithoutPlaceholderIsNotGivenRegex(): void
+    {
+        $processor = new Processor();
+
+        $route = new DynamicRoute(
+            path: '/static/path',
+            name: 'route',
+            regex: '',
+            parameters: [],
+            handler: static fn (): null => null,
+        );
+
+        $routeAfterProcessing = $processor->route($route);
+
+        self::assertInstanceOf(DynamicRoute::class, $routeAfterProcessing);
+        self::assertSame('/static/path', $routeAfterProcessing->getPath());
+        self::assertSame('', $routeAfterProcessing->getRegex());
+    }
+
+    /**
+     * A non-dynamic route containing `{` in its path is not treated as dynamic (no regex).
+     */
+    public function testNonDynamicRouteWithBraceInPathIsLeftAsStatic(): void
+    {
+        $processor = new Processor();
+
+        $route = new Route(
+            path: '/{notDynamic}',
+            name: 'route',
+            handler: static fn (): null => null,
+        );
+
+        $routeAfterProcessing = $processor->route($route);
+
+        self::assertNotInstanceOf(DynamicRoute::class, $routeAfterProcessing);
+        self::assertSame('/{notDynamic}', $routeAfterProcessing->getPath());
+    }
+
+    /**
+     * Build the produced regex for a dynamic route from a path and its parameters.
+     *
+     * @param non-empty-string $path
+     * @param array<Parameter> $parameters
+     *
+     * @throws HttpRoutingInvalidRoutePathException
+     */
+    private function processRegex(string $path, array $parameters): string
+    {
+        $route = new DynamicRoute(
+            path: $path,
+            name: 'route',
+            regex: '',
+            parameters: $parameters,
+            handler: static fn (): null => null,
+        );
+
+        $processed = new Processor()->route($route);
+
+        self::assertInstanceOf(DynamicRoute::class, $processed);
+
+        return $processed->getRegex();
     }
 }


### PR DESCRIPTION
# Description

The HTTP routing code (`Processor`, `Matcher`, `AttributeRouteCollector`) already
reported 100% line and branch coverage, but that coverage was shallow on
*combinations*: the existing tests exercised a single parameter type, one optional
parameter, one non-capturing parameter, etc. — enough to touch each line/branch once,
but not enough to prove that arbitrary developer-authored routes produce the correct
regex and match correctly.

This PR adds combination-matrix tests so a developer can trust that any route they
define — via direct `Route`/`DynamicRoute` construction **or** via attributes — produces
the expected regex and matches request paths correctly. It adds tests only; there are no
source changes, so coverage cannot drop.

Highlights:
- **Exact regex production** is now asserted (not just non-empty) across every `Regex`
  parameter type, structural layouts (parameter at start/middle/end, multiple/adjacent
  parameters, static+dynamic mixes), and modifiers (optional, multiple optional,
  non-capture, optional+non-capture, the `{name?}` auto-optional path), plus the guard
  branches. Each produced regex is also asserted to be valid PCRE.
- **Matching correctness** is verified per parameter type (valid input matches and binds,
  invalid input is rejected) and — for the first time — **request-method filtering**
  (every prior `Matcher` test used `RequestMethod::ANY`), trailing-slash normalization,
  static-over-dynamic precedence, multi-parameter extraction, and non-capturing
  parameters not being bound.
- The **attribute construction path** is asserted to produce the same regex as direct
  construction via a new controller fixture.

Part of a cross-language effort; sibling Java and TypeScript PRs will follow.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/Tests/Unit/Http/Routing/Processor/ProcessorTest.php`** — added data-provider matrices asserting the exact regex produced for every parameter type, structural combination, and modifier combination; added the `{name?}` auto-optional case and the dynamic-without-placeholder / non-dynamic-with-brace guard branches.
- **`tests/Tests/Unit/Http/Routing/Matcher/MatcherTest.php`** — added a per-type valid-matches/invalid-rejected matrix plus request-method filtering, trailing-slash normalization, static-over-dynamic precedence, multi-parameter extraction, and non-capturing-parameter-not-bound tests, driven end-to-end through the `Processor`.
- **`tests/Tests/Unit/Http/Routing/Collector/AttributeRouteCollectorTest.php`** — added a test asserting the attribute path produces the same regex as direct construction across a type/modifier/multi-parameter matrix.
- **`tests/Tests/Fixtures/Http/Routing/Controller/RoutingCombinationsControllerFixture.php`** — new controller fixture defining attribute routes covering the combination matrix.
