### PR TITLE
[Cli] Add routing argument/option combination tests

### DIFF
--- a/tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterPermutationsFixture.php
+++ b/tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterPermutationsFixture.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Cli\Routing\Command;
+
+use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Message;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Attribute\ArgumentParameter;
+use Valkyrja\Cli\Routing\Attribute\OptionParameter;
+use Valkyrja\Cli\Routing\Attribute\Route;
+use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+use Valkyrja\Cli\Routing\Enum\ArgumentMode;
+use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
+use Valkyrja\Cli\Routing\Enum\OptionMode;
+use Valkyrja\Cli\Routing\Enum\OptionValueMode;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+
+/**
+ * Command fixture exercising the argument/option mode and value-mode permutations not
+ * covered by CommandWithAllAttributesFixture (which only covers REQUIRED + ARRAY): an
+ * optional single-value argument, an optional single-value long-only option, and a
+ * valueless (NONE) flag option.
+ */
+final class CommandWithParameterPermutationsFixture
+{
+    /** @var non-empty-string */
+    public const string NAME = 'permutations';
+    /** @var non-empty-string */
+    public const string DESCRIPTION = 'A permutations command';
+    /** @var non-empty-string */
+    public const string HELP_TEXT = 'A permutations command';
+
+    /**
+     * The help text.
+     */
+    public static function help(): MessageContract
+    {
+        return new Message(self::HELP_TEXT);
+    }
+
+    /**
+     * Handler for the command.
+     */
+    public static function handler(ContainerContract $container, RouteContract $route): OutputContract
+    {
+        return new self()->run(
+            $container->getSingleton(OutputFactoryContract::class)
+        );
+    }
+
+    #[Route(
+        name: self::NAME,
+        description: self::DESCRIPTION,
+        helpText: [self::class, 'help'],
+    )]
+    #[RouteHandler([self::class, 'handler'])]
+    #[ArgumentParameter(
+        name: 'optionalArgument',
+        description: 'An optional single-value argument',
+        mode: ArgumentMode::OPTIONAL,
+        valueMode: ArgumentValueMode::DEFAULT,
+    )]
+    #[OptionParameter(
+        name: 'optionalOption',
+        description: 'An optional single-value long-only option',
+        mode: OptionMode::OPTIONAL,
+        valueMode: OptionValueMode::DEFAULT,
+    )]
+    #[OptionParameter(
+        name: 'flag',
+        description: 'A valueless flag option',
+        mode: OptionMode::OPTIONAL,
+        valueMode: OptionValueMode::NONE,
+    )]
+    public function run(OutputFactoryContract $outputFactory): OutputContract
+    {
+        return $outputFactory->createOutput()->withMessages(new Message(self::NAME));
+    }
+}

--- a/tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php
@@ -32,6 +32,7 @@ use Valkyrja\Tests\Fixtures\Cli\Middleware\ThrowableCaughtMiddlewareFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithAllAttributesFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithAllMiddlewareFixture;
+use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithParameterPermutationsFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Enum\CastType;
 
@@ -136,5 +137,50 @@ final class AttributeRouteCollectorTest extends TestCase
         self::assertSame([AllMiddlewareFixture::class], $route->getRouteMatchedMiddleware());
         self::assertSame([AllMiddlewareFixture::class], $route->getProcessExitingMiddleware());
         self::assertSame([AllMiddlewareFixture::class], $route->getThrowableCaughtMiddleware());
+    }
+
+    /**
+     * The attribute path converts the complementary argument/option permutations
+     * (optional single-value argument, optional long-only option, and a NONE flag) into
+     * data-class parameters with the expected modes and value modes.
+     *
+     * @throws ReflectionException
+     */
+    public function testGetCommandsWithParameterPermutations(): void
+    {
+        $collector = new AttributeRouteCollector(
+            attributes: new Collector(),
+            reflection: new Reflector()
+        );
+
+        $commands = $collector->getRoutes(CommandWithParameterPermutationsFixture::class);
+
+        self::assertCount(1, $commands);
+        self::assertInstanceOf(Route::class, $command = $commands[0]);
+
+        // Optional, single-value argument.
+        $argument = $command->getArgument('optionalArgument');
+
+        self::assertInstanceOf(ArgumentParameter::class, $argument);
+        self::assertSame(ArgumentMode::OPTIONAL, $argument->getMode());
+        self::assertSame(ArgumentValueMode::DEFAULT, $argument->getValueMode());
+        self::assertFalse($argument->hasCast());
+
+        // Optional, single-value, long-only option (no short names, no valid values).
+        $option = $command->getOption('optionalOption');
+
+        self::assertInstanceOf(OptionParameter::class, $option);
+        self::assertSame(OptionMode::OPTIONAL, $option->getMode());
+        self::assertSame(OptionValueMode::DEFAULT, $option->getValueMode());
+        self::assertSame([], $option->getShortNames());
+        self::assertSame([], $option->getValidValues());
+        self::assertFalse($option->hasCast());
+
+        // Valueless (NONE) flag option.
+        $flag = $command->getOption('flag');
+
+        self::assertInstanceOf(OptionParameter::class, $flag);
+        self::assertSame(OptionMode::OPTIONAL, $flag->getMode());
+        self::assertSame(OptionValueMode::NONE, $flag->getValueMode());
     }
 }

--- a/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
@@ -27,7 +27,13 @@ use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Data\Route;
 use Valkyrja\Cli\Routing\Dispatcher\Router;
+use Valkyrja\Cli\Routing\Enum\ArgumentMode;
 use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
+use Valkyrja\Cli\Routing\Enum\OptionMode;
+use Valkyrja\Cli\Routing\Enum\OptionValueMode;
+use Valkyrja\Cli\Routing\Throwable\Exception\CliRoutingArgumentValuesValidationException;
+use Valkyrja\Cli\Routing\Throwable\Exception\CliRoutingInvalidOptionWithValueException;
+use Valkyrja\Cli\Routing\Throwable\Exception\CliRoutingOptionValuesValidationException;
 use Valkyrja\Container\Manager\Container;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -239,6 +245,237 @@ final class RouterTest extends TestCase
 
         self::assertSame(ExitCode::SUCCESS, $output->getExitCode());
         self::assertSame($inputOptions, $routeAfterOutput->getOption('option')->getOptions());
+    }
+
+    public function testDispatchRouteBindsOptionByShortName(): void
+    {
+        $container = new Container();
+        $router    = new Router(container: $container);
+        $option    = new Option(name: 'f');
+        $input     = new Input(commandName: 'test-command', options: [$option]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'force',
+                    description: 'Force the command',
+                    shortNames: ['f'],
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+
+        $routeAfterOutput = $container->get(RouteContract::class);
+
+        self::assertSame([$option], $routeAfterOutput->getOption('force')->getOptions());
+    }
+
+    public function testDispatchRouteBindsMultipleOptionsToArrayOption(): void
+    {
+        $container = new Container();
+        $router    = new Router(container: $container);
+        $optionA   = new Option(name: 'tag', value: 'a');
+        $optionB   = new Option(name: 'tag', value: 'b');
+        $input     = new Input(commandName: 'test-command', options: [$optionA, $optionB]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'tag',
+                    description: 'A repeatable tag',
+                    valueMode: OptionValueMode::ARRAY,
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+
+        $routeAfterOutput = $container->get(RouteContract::class);
+
+        self::assertSame([$optionA, $optionB], $routeAfterOutput->getOption('tag')->getOptions());
+    }
+
+    public function testDispatchRouteLeavesUnmatchedOptionParameterEmpty(): void
+    {
+        $container = new Container();
+        $router    = new Router(container: $container);
+        $input     = new Input(commandName: 'test-command', options: [new Option(name: 'other')]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'unused',
+                    description: 'Never provided',
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+
+        $routeAfterOutput = $container->get(RouteContract::class);
+
+        self::assertSame([], $routeAfterOutput->getOption('unused')->getOptions());
+    }
+
+    public function testDispatchRouteThrowsWhenNoneFlagReceivesValue(): void
+    {
+        $this->expectException(CliRoutingInvalidOptionWithValueException::class);
+
+        $router = new Router();
+        $input  = new Input(commandName: 'test-command', options: [new Option(name: 'flag', value: 'nope')]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'flag',
+                    description: 'A valueless flag',
+                    valueMode: OptionValueMode::NONE,
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+    }
+
+    public function testDispatchRouteThrowsWhenRequiredOptionMissing(): void
+    {
+        $this->expectException(CliRoutingOptionValuesValidationException::class);
+
+        $router = new Router();
+        $input  = new Input(commandName: 'test-command');
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'required',
+                    description: 'A required option',
+                    mode: OptionMode::REQUIRED,
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+    }
+
+    public function testDispatchRouteThrowsWhenDefaultOptionReceivesMultiple(): void
+    {
+        $this->expectException(CliRoutingOptionValuesValidationException::class);
+
+        $router = new Router();
+        $input  = new Input(
+            commandName: 'test-command',
+            options: [new Option(name: 'single', value: 'a'), new Option(name: 'single', value: 'b')]
+        );
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            options: [
+                new OptionParameter(
+                    name: 'single',
+                    description: 'A single-value option',
+                    valueMode: OptionValueMode::DEFAULT,
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+    }
+
+    public function testDispatchRouteWithFewerArgumentsThanParameters(): void
+    {
+        $container = new Container();
+        $router    = new Router(container: $container);
+        $argument  = new Argument(value: 'only');
+        $input     = new Input(commandName: 'test-command', arguments: [$argument]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            arguments: [
+                new ArgumentParameter(name: 'first', description: 'First argument'),
+                new ArgumentParameter(name: 'second', description: 'Second argument'),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+
+        $routeAfterOutput = $container->get(RouteContract::class);
+
+        self::assertSame([$argument], $routeAfterOutput->getArgument('first')->getArguments());
+        self::assertSame([], $routeAfterOutput->getArgument('second')->getArguments());
+    }
+
+    public function testDispatchRouteThrowsWhenRequiredArgumentMissing(): void
+    {
+        $this->expectException(CliRoutingArgumentValuesValidationException::class);
+
+        $router = new Router();
+        $input  = new Input(commandName: 'test-command');
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            arguments: [
+                new ArgumentParameter(
+                    name: 'required',
+                    description: 'A required argument',
+                    mode: ArgumentMode::REQUIRED,
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+    }
+
+    public function testDispatchRouteArrayArgumentConsumesRemaining(): void
+    {
+        $container = new Container();
+        $router    = new Router(container: $container);
+        $first     = new Argument(value: 'a');
+        $restB     = new Argument(value: 'b');
+        $restC     = new Argument(value: 'c');
+        $input     = new Input(commandName: 'test-command', arguments: [$first, $restB, $restC]);
+
+        $route = new Route(
+            name: 'test-command',
+            description: 'Test Command',
+            handler: [self::class, 'dispatch'],
+            arguments: [
+                new ArgumentParameter(name: 'first', description: 'First argument'),
+                new ArgumentParameter(
+                    name: 'rest',
+                    description: 'Remaining arguments',
+                    valueMode: ArgumentValueMode::ARRAY
+                ),
+            ]
+        );
+
+        $router->dispatchRoute($input, $route);
+
+        $routeAfterOutput = $container->get(RouteContract::class);
+
+        self::assertSame([$first], $routeAfterOutput->getArgument('first')->getArguments());
+        self::assertSame([$restB, $restC], $routeAfterOutput->getArgument('rest')->getArguments());
     }
 
     public function testHelpRoute(): void


### PR DESCRIPTION
# Description

The CLI routing code (`Router` binding, `AttributeRouteCollector`) already reported 100%
line and branch coverage, but that coverage was shallow on *combinations*: the existing
`RouterTest` bound a single long-named option and a single argument, so most of the
argument/option permutation surface a developer relies on went unproven.

This PR adds combination tests so a developer can trust that any command they define —
with any mix of argument and option types, via direct `Route` construction **or** via
attributes — is bound and validated correctly. It adds tests only; there are no source
changes, so coverage cannot drop.

CLI routing is not regex-based (unlike HTTP): matching is exact command-name lookup, then
positional argument binding and name/short-name option binding, with per-parameter
validation. These tests exercise that binding/validation surface end to end through
`Router::dispatchRoute`.

Highlights:
- **Option binding**: matched by short name; multiple inputs collected into an `ARRAY`
  option; an option parameter that matches zero inputs; a `NONE` flag that receives a
  value throws; a `REQUIRED` option that is missing throws; a `DEFAULT` option that
  receives more than one value throws.
- **Argument binding**: fewer inputs than declared parameters (the unset-index branch); a
  missing `REQUIRED` argument throws; an `ARRAY` argument consumes the remaining inputs.
- **Attribute path**: a new command fixture covers the argument/option mode and value-mode
  permutations not previously exercised by attributes (optional single-value argument,
  optional long-only option, and a `NONE` flag), asserting the converted data-class
  parameters.

Sibling of the HTTP routing combination tests in #923; part of a cross-language effort
(Java and TypeScript PRs to follow).

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php`** — added an option/argument binding matrix through `dispatchRoute`: short-name option match, ARRAY option collecting multiple, zero-match option, NONE-flag-with-value throw, REQUIRED-option-missing throw, DEFAULT-option-multiple throw, fewer-arguments-than-parameters, REQUIRED-argument-missing throw, and ARRAY-argument-consumes-remaining.
- **`tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php`** — added a test asserting the attribute path converts the complementary argument/option permutations (optional single-value argument, optional long-only option, NONE flag) into data-class parameters with the correct modes and value modes.
- **`tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterPermutationsFixture.php`** — new command fixture defining those complementary permutations via attributes.
