### PR TITLE
[Cli] Enforce option valid values in areValuesValid

### DIFF
--- a/src/Valkyrja/Cli/Routing/Data/OptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/OptionParameter.php
@@ -336,6 +336,14 @@ class OptionParameter extends Parameter implements OptionParameterContract
             $valid = $valid && count($this->options) <= 1;
         }
 
+        if ($this->validValues !== []) {
+            foreach ($this->options as $option) {
+                if (! in_array($option->getValue(), $this->validValues, true)) {
+                    return false;
+                }
+            }
+        }
+
         return $valid;
     }
 

--- a/tests/Tests/Unit/Cli/Routing/Data/OptionParameterTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Data/OptionParameterTest.php
@@ -894,4 +894,88 @@ final class OptionParameterTest extends TestCase
 
         self::assertSame($parameter, $parameter->validateValues());
     }
+
+    public function testAreValuesValidWithValidValues(): void
+    {
+        $name         = self::NAME;
+        $description  = self::DESCRIPTION;
+        $validValue   = new Option('option', 'a');
+        $validValue2  = new Option('option2', 'b');
+        $invalidValue = new Option('option3', 'c');
+
+        $parameter = new OptionParameter(
+            name: $name,
+            description: $description,
+            validValues: ['a', 'b'],
+        );
+
+        // Empty valid values impose no constraint on the bound value
+        $unconstrained = new OptionParameter(name: $name, description: $description)
+            ->withOptions($invalidValue);
+        // A provided value that is a member of the valid values passes
+        $valid = $parameter->withOptions($validValue);
+        // A provided value that is not a member of the valid values fails
+        $invalid = $parameter->withOptions($invalidValue);
+        // ARRAY: every provided value must be a member of the valid values
+        $arrayAllValid = $parameter
+            ->withValueMode(OptionValueMode::ARRAY)
+            ->withOptions($validValue, $validValue2);
+        // ARRAY: a single invalid value among several fails
+        $arrayOneInvalid = $parameter
+            ->withValueMode(OptionValueMode::ARRAY)
+            ->withOptions($validValue, $validValue2, $invalidValue);
+        // Non-empty valid values with no bound options impose no failure
+        $noOptions = $parameter;
+        // Interaction with REQUIRED: a required, member value passes
+        $requiredValid = $parameter
+            ->withMode(OptionMode::REQUIRED)
+            ->withOptions($validValue);
+        // Interaction with REQUIRED: a required, non-member value fails
+        $requiredInvalid = $parameter
+            ->withMode(OptionMode::REQUIRED)
+            ->withOptions($invalidValue);
+
+        self::assertTrue($unconstrained->areValuesValid());
+        self::assertTrue($valid->areValuesValid());
+        self::assertFalse($invalid->areValuesValid());
+        self::assertTrue($arrayAllValid->areValuesValid());
+        self::assertFalse($arrayOneInvalid->areValuesValid());
+        self::assertTrue($noOptions->areValuesValid());
+        self::assertTrue($requiredValid->areValuesValid());
+        self::assertFalse($requiredInvalid->areValuesValid());
+    }
+
+    public function testValidateValuesThrowsOnInvalidValue(): void
+    {
+        $this->expectException(CliRoutingOptionValuesValidationException::class);
+
+        $name        = self::NAME;
+        $description = self::DESCRIPTION;
+        $option      = new Option('option', 'c');
+
+        $parameter = new OptionParameter(
+            name: $name,
+            description: $description,
+            validValues: ['a', 'b'],
+        );
+
+        $parameter->withOptions($option)->validateValues();
+    }
+
+    public function testValidateValuesPassesWithValidValue(): void
+    {
+        $name        = self::NAME;
+        $description = self::DESCRIPTION;
+        $option      = new Option('option', 'a');
+
+        $parameter = new OptionParameter(
+            name: $name,
+            description: $description,
+            validValues: ['a', 'b'],
+        );
+
+        $valid = $parameter->withOptions($option);
+
+        self::assertSame($valid, $valid->validateValues());
+    }
 }


### PR DESCRIPTION
# Description

CLI option `validValues` (the allowed values for an option) were stored, exposed via getters/withers, and carried through the `AttributeRouteCollector` to help output — but never actually enforced. `areValuesValid()` only checked the option `mode` (`REQUIRED` ⇒ at least one option present) and `valueMode` (`DEFAULT` ⇒ at most one option); it never checked that a provided value was a member of `validValues`. As a result an option declared with `validValues` such as `['json', 'xml']` still accepted `--format=csv`.

This PR enforces `validValues` in `areValuesValid()`: when `validValues` is non-empty, every bound option value must be a member of `validValues`, otherwise `validateValues()` throws the existing `CliRoutingOptionValuesValidationException`. An empty `validValues` imposes no constraint (unchanged). The check composes with `valueMode` `NONE`/`DEFAULT`/`ARRAY` (for `ARRAY`, every provided value must be valid) and with `OptionMode` `REQUIRED`/`OPTIONAL`.

PHP is the reference implementation; the Java and TypeScript ports mirror its behavior. This is one of three sibling PRs — see **Sibling PRs** below.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes
- **`src/Valkyrja/Cli/Routing/Data/OptionParameter.php`** — `areValuesValid()` now returns `false` (so `validateValues()` throws `CliRoutingOptionValuesValidationException`) when any bound option value is not a member of a non-empty `validValues` list; an empty list is unconstrained.
- **`tests/Tests/Unit/Cli/Routing/Data/OptionParameterTest.php`** — added combination tests: member value passes, non-member fails, empty `validValues` imposes no constraint, `ARRAY` with one invalid among several fails, `REQUIRED`/`OPTIONAL` interaction, and `validateValues()` throwing on an invalid value / returning `$this` on a valid one.

## Sibling PRs

This change is applied across all three affected language ports in the same batch:

- **PHP** (reference): https://github.com/valkyrjaio/valkyrja-php/pull/925
- **Java**: https://github.com/valkyrjaio/valkyrja-java/pull/47
- **TypeScript**: https://github.com/valkyrjaio/valkyrja-ts/pull/86
