### PR TITLE
[Session] Coerce null cookie domain to empty string in PhpSession

### DIFF
--- a/src/Valkyrja/Session/Manager/PhpSession.php
+++ b/src/Valkyrja/Session/Manager/PhpSession.php
@@ -64,7 +64,7 @@ class PhpSession extends Session
         // Set the session cookie parameters
         session_set_cookie_params([
             'path'     => $this->cookieParams->path,
-            'domain'   => $this->cookieParams->domain,
+            'domain'   => $this->cookieParams->domain ?? '',
             'lifetime' => $this->cookieParams->lifetime,
             'secure'   => $this->cookieParams->secure,
             'httponly' => $this->cookieParams->httpOnly,

--- a/tests/Tests/Unit/Session/Manager/PhpSessionTest.php
+++ b/tests/Tests/Unit/Session/Manager/PhpSessionTest.php
@@ -88,6 +88,22 @@ final class PhpSessionTest extends TestCase
         self::assertSame(1, $session->sessionStartCount);
     }
 
+    public function testStartWithNonNullDomain(): void
+    {
+        $cookieParams = new CookieParams(
+            path: '/',
+            domain: 'example.com',
+            lifetime: 0,
+            secure: false,
+            httpOnly: false,
+            sameSite: SameSite::NONE,
+        );
+
+        $session = new PhpSession($cookieParams);
+
+        self::assertSame(PHP_SESSION_ACTIVE, session_status());
+    }
+
     public function testConstructorWithSessionIdAndName(): void
     {
         $session = new PhpSession($this->cookieParams, 'test-session-id', 'MY_SESSION');


### PR DESCRIPTION
# Description

PHPStan reports an `argument.type` error in `PhpSession::start()`: the array passed to `session_set_cookie_params()` sets `'domain' => $this->cookieParams->domain`, but `CookieParams::$domain` is typed `string|null` (default `null`), while the stdlib signature expects a non-null `string` (where `''` means "no domain"). This surfaces under the PHP 8.5 stubs; the repo targets PHP `>=8.4`, so it is non-blocking in CI today but is a real type mismatch that should be fixed properly rather than suppressed.

The fix coerces `null` to `''` (`$this->cookieParams->domain ?? ''`), matching the stdlib's "no domain" sentinel, so the value is always a `string`. No suppression, cast-to-silence, baseline entry, or type widening is used.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Session/Manager/PhpSession.php`** — coerce a null cookie `domain` to `''` (`$this->cookieParams->domain ?? ''`) so `session_set_cookie_params()` always receives a `string`, resolving the PHPStan `argument.type` error.
- **`tests/Tests/Unit/Session/Manager/PhpSessionTest.php`** — added `testStartWithNonNullDomain()` covering the non-null `domain` branch of the new `??` (the existing `setUp()` already exercises the null branch), keeping `PhpSession` at 100% line and branch coverage.
