### PR TITLE
[Cli] Add routing attribute parameter combination tests

### DIFF
--- a/tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterCombinationsFixture.php
+++ b/tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterCombinationsFixture.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Cli\Routing\Command;
+
+use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Message;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Attribute\ArgumentParameter;
+use Valkyrja\Cli\Routing\Attribute\OptionParameter;
+use Valkyrja\Cli\Routing\Attribute\Route;
+use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+use Valkyrja\Cli\Routing\Enum\ArgumentMode;
+use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
+use Valkyrja\Cli\Routing\Enum\OptionMode;
+use Valkyrja\Cli\Routing\Enum\OptionValueMode;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+
+/**
+ * Command fixture exercising a full matrix of argument and option modes/value-modes so the
+ * attribute construction path can be asserted to convert every permutation into the
+ * expected data-class parameters. Mirrors the Java CliRoutingCombinationsController.
+ */
+final class CommandWithParameterCombinationsFixture
+{
+    /** @var non-empty-string */
+    public const string NAME = 'combinations';
+    /** @var non-empty-string */
+    public const string DESCRIPTION = 'A combinations command';
+    /** @var non-empty-string */
+    public const string HELP_TEXT = 'A combinations command';
+
+    /**
+     * The help text.
+     */
+    public static function help(): MessageContract
+    {
+        return new Message(self::HELP_TEXT);
+    }
+
+    /**
+     * Handler for the command.
+     */
+    public static function handler(ContainerContract $container, RouteContract $route): OutputContract
+    {
+        return new self()->run(
+            $container->getSingleton(OutputFactoryContract::class)
+        );
+    }
+
+    #[Route(
+        name: self::NAME,
+        description: self::DESCRIPTION,
+        helpText: [self::class, 'help'],
+    )]
+    #[RouteHandler([self::class, 'handler'])]
+    #[ArgumentParameter(
+        name: 'required',
+        description: 'A required single-value argument',
+        mode: ArgumentMode::REQUIRED,
+        valueMode: ArgumentValueMode::DEFAULT,
+    )]
+    #[ArgumentParameter(
+        name: 'rest',
+        description: 'An optional array argument',
+        mode: ArgumentMode::OPTIONAL,
+        valueMode: ArgumentValueMode::ARRAY,
+    )]
+    #[OptionParameter(
+        name: 'format',
+        description: 'A required single-value option',
+        valueDisplayName: 'fmt',
+        defaultValue: 'json',
+        shortNames: ['f'],
+        validValues: ['json', 'xml'],
+        mode: OptionMode::REQUIRED,
+        valueMode: OptionValueMode::DEFAULT,
+    )]
+    #[OptionParameter(
+        name: 'flag',
+        description: 'A valueless flag option',
+        mode: OptionMode::OPTIONAL,
+        valueMode: OptionValueMode::NONE,
+    )]
+    #[OptionParameter(
+        name: 'tags',
+        description: 'A repeatable array option',
+        valueMode: OptionValueMode::ARRAY,
+    )]
+    public function run(OutputFactoryContract $outputFactory): OutputContract
+    {
+        return $outputFactory->createOutput()->withMessages(new Message(self::NAME));
+    }
+}

--- a/tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php
@@ -32,6 +32,7 @@ use Valkyrja\Tests\Fixtures\Cli\Middleware\ThrowableCaughtMiddlewareFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithAllAttributesFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithAllMiddlewareFixture;
+use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithParameterCombinationsFixture;
 use Valkyrja\Tests\Fixtures\Cli\Routing\Command\CommandWithParameterPermutationsFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Enum\CastType;
@@ -182,5 +183,63 @@ final class AttributeRouteCollectorTest extends TestCase
         self::assertInstanceOf(OptionParameter::class, $flag);
         self::assertSame(OptionMode::OPTIONAL, $flag->getMode());
         self::assertSame(OptionValueMode::NONE, $flag->getValueMode());
+    }
+
+    /**
+     * The attribute path converts a full matrix of argument and option modes/value-modes
+     * (mirroring the Java CliRoutingCombinationsController) into data-class parameters with
+     * the expected modes, value modes, short names, valid values, default, and display name.
+     *
+     * @throws ReflectionException
+     */
+    public function testGetCommandsWithParameterCombinations(): void
+    {
+        $collector = new AttributeRouteCollector(
+            attributes: new Collector(),
+            reflection: new Reflector()
+        );
+
+        $commands = $collector->getRoutes(CommandWithParameterCombinationsFixture::class);
+
+        self::assertCount(1, $commands);
+        self::assertInstanceOf(Route::class, $command = $commands[0]);
+
+        // Required, single-value argument.
+        $required = $command->getArgument('required');
+
+        self::assertInstanceOf(ArgumentParameter::class, $required);
+        self::assertSame(ArgumentMode::REQUIRED, $required->getMode());
+        self::assertSame(ArgumentValueMode::DEFAULT, $required->getValueMode());
+
+        // Optional, array argument.
+        $rest = $command->getArgument('rest');
+
+        self::assertInstanceOf(ArgumentParameter::class, $rest);
+        self::assertSame(ArgumentMode::OPTIONAL, $rest->getMode());
+        self::assertSame(ArgumentValueMode::ARRAY, $rest->getValueMode());
+
+        // Required, single-value option carrying short names, valid values, default, display name.
+        $format = $command->getOption('format');
+
+        self::assertInstanceOf(OptionParameter::class, $format);
+        self::assertSame(OptionMode::REQUIRED, $format->getMode());
+        self::assertSame(OptionValueMode::DEFAULT, $format->getValueMode());
+        self::assertSame(['f'], $format->getShortNames());
+        self::assertSame(['json', 'xml'], $format->getValidValues());
+        self::assertSame('json', $format->getDefaultValue());
+        self::assertSame('fmt', $format->getValueDisplayName());
+
+        // Valueless (NONE) flag option.
+        $flag = $command->getOption('flag');
+
+        self::assertInstanceOf(OptionParameter::class, $flag);
+        self::assertSame(OptionMode::OPTIONAL, $flag->getMode());
+        self::assertSame(OptionValueMode::NONE, $flag->getValueMode());
+
+        // Repeatable (ARRAY) option.
+        $tags = $command->getOption('tags');
+
+        self::assertInstanceOf(OptionParameter::class, $tags);
+        self::assertSame(OptionValueMode::ARRAY, $tags->getValueMode());
     }
 }


### PR DESCRIPTION
# Description

Follow-up to the merged CLI routing combination tests (#924), bringing PHP to parity with
the additional attribute coverage added to the Java port
(valkyrjaio/valkyrja-java#49, merged).

Java #49 asserts, in one focused test, that the annotation path converts a full matrix of
argument and option modes/value-modes into the expected data-class parameters — checking
every converted field (mode, value mode, short names, valid values, default, display name),
not just that a parameter is present. This adds the equivalent PHP fixture and test so both
ports assert the same matrix. Test-only; no source changes.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/Tests/Unit/Cli/Routing/Collector/AttributeRouteCollectorTest.php`** — added `testGetCommandsWithParameterCombinations` asserting the attribute path converts a full matrix — argument REQUIRED/DEFAULT and OPTIONAL/ARRAY; option REQUIRED/DEFAULT (with short names, valid values, default, display name), OPTIONAL/NONE, and OPTIONAL/ARRAY — into data-class parameters with the expected fields.
- **`tests/Tests/Fixtures/Cli/Routing/Command/CommandWithParameterCombinationsFixture.php`** — new command fixture mirroring the Java `CliRoutingCombinationsController`.
