### PR TITLE
[Http] Add request, response, and CLI input message-mapping fidelity tests

### DIFF
--- a/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
+++ b/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Functional\Cli\Interaction\Input;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Valkyrja\Cli\Interaction\Argument\Contract\ArgumentContract;
+use Valkyrja\Cli\Interaction\Enum\OptionType;
+use Valkyrja\Cli\Interaction\Input\Factory\InputFactory;
+use Valkyrja\Cli\Interaction\Option\Contract\OptionContract;
+use Valkyrja\Cli\Interaction\Throwable\Exception\CliInteractionInvalidEmptyValueException;
+use Valkyrja\Cli\Interaction\Throwable\Exception\CliInteractionInvalidNonEmptyValueException;
+use Valkyrja\Tests\Functional\Abstract\TestCase;
+
+use function array_map;
+use function array_values;
+
+/**
+ * Message-mapping fidelity for an incoming CLI command.
+ *
+ * Asserts that an argv-style array lands on the framework's own Input,
+ * Argument, and Option objects exactly as spelled, independent of routing.
+ */
+final class InputMappingTest extends TestCase
+{
+    /** @var non-empty-string */
+    private const string DEFAULT_CALLER = 'valkyrja';
+
+    /** @var non-empty-string */
+    private const string DEFAULT_COMMAND = 'list';
+
+    /**
+     * Every option spelling the factory supports.
+     *
+     * @return array<string, array{non-empty-string[], list<array{string, string, OptionType}>}>
+     */
+    public static function provideOptionSpellings(): array
+    {
+        return [
+            'long with value'         => [
+                ['valkyrja', 'cmd', '--name=value'],
+                [['name', 'value', OptionType::LONG]],
+            ],
+            'long without value'      => [
+                ['valkyrja', 'cmd', '--verbose'],
+                [['verbose', '', OptionType::LONG]],
+            ],
+            'long with empty value'   => [
+                ['valkyrja', 'cmd', '--name='],
+                [['name', '', OptionType::LONG]],
+            ],
+            'short without value'     => [
+                ['valkyrja', 'cmd', '-v'],
+                [['v', '', OptionType::SHORT]],
+            ],
+            'short with value'        => [
+                ['valkyrja', 'cmd', '-n=value'],
+                [['n', 'value', OptionType::SHORT]],
+            ],
+            'bundled short flags'     => [
+                ['valkyrja', 'cmd', '-abc'],
+                [
+                    ['a', '', OptionType::SHORT],
+                    ['b', '', OptionType::SHORT],
+                    ['c', '', OptionType::SHORT],
+                ],
+            ],
+            'repeated long option'    => [
+                ['valkyrja', 'cmd', '--tag=one', '--tag=two'],
+                [
+                    ['tag', 'one', OptionType::LONG],
+                    ['tag', 'two', OptionType::LONG],
+                ],
+            ],
+            'mixed long and short'    => [
+                ['valkyrja', 'cmd', '--name=value', '-v', '-ab'],
+                [
+                    ['name', 'value', OptionType::LONG],
+                    ['v', '', OptionType::SHORT],
+                    ['a', '', OptionType::SHORT],
+                    ['b', '', OptionType::SHORT],
+                ],
+            ],
+            'value containing equals' => [
+                ['valkyrja', 'cmd', '--expr=a=b'],
+                [['expr', 'a', OptionType::LONG]],
+            ],
+        ];
+    }
+
+    /**
+     * Spellings the factory rejects.
+     *
+     * @return array<string, array{non-empty-string[], class-string}>
+     */
+    public static function provideRejectedSpellings(): array
+    {
+        return [
+            'double dash terminator'   => [
+                ['valkyrja', 'cmd', '--'],
+                CliInteractionInvalidNonEmptyValueException::class,
+            ],
+            'single dash'              => [
+                ['valkyrja', 'cmd', '-'],
+                CliInteractionInvalidNonEmptyValueException::class,
+            ],
+            'bundled short with value' => [
+                ['valkyrja', 'cmd', '-abc=value'],
+                CliInteractionInvalidEmptyValueException::class,
+            ],
+        ];
+    }
+
+    /**
+     * @param ArgumentContract[] $arguments
+     *
+     * @return list<string>
+     */
+    private static function argumentValues(array $arguments): array
+    {
+        return array_values(
+            array_map(
+                static fn (ArgumentContract $argument): string => $argument->getValue(),
+                $arguments
+            )
+        );
+    }
+
+    /**
+     * @param OptionContract[] $options
+     *
+     * @return list<array{string, string, OptionType}>
+     */
+    private static function optionTuples(array $options): array
+    {
+        return array_values(
+            array_map(
+                static fn (OptionContract $option): array => [
+                    $option->getName(),
+                    $option->getValue(),
+                    $option->getType(),
+                ],
+                $options
+            )
+        );
+    }
+
+    /**
+     * The first argv entry becomes the caller and the second becomes the command name.
+     */
+    public function testCallerAndCommandNameMapFromArgv(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['bin/valkyrja', 'app:version'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: 'bin/valkyrja', actual: $input->getCaller());
+        self::assertSame(expected: 'app:version', actual: $input->getCommandName());
+        self::assertSame(expected: [], actual: $input->getArguments());
+        self::assertSame(expected: [], actual: $input->getOptions());
+    }
+
+    /**
+     * The supplied defaults stand in when argv carries no command name.
+     */
+    public function testDefaultsApplyWhenArgvIsBare(): void
+    {
+        $input = InputFactory::fromGlobals(['bin/valkyrja'], self::DEFAULT_CALLER, self::DEFAULT_COMMAND);
+
+        self::assertSame(expected: 'bin/valkyrja', actual: $input->getCaller());
+        self::assertSame(expected: self::DEFAULT_COMMAND, actual: $input->getCommandName());
+
+        $empty = InputFactory::fromGlobals([], self::DEFAULT_CALLER, self::DEFAULT_COMMAND);
+
+        self::assertSame(expected: self::DEFAULT_CALLER, actual: $empty->getCaller());
+        self::assertSame(expected: self::DEFAULT_COMMAND, actual: $empty->getCommandName());
+    }
+
+    /**
+     * Everything after the command name that is not an option becomes a positional
+     * argument, in argv order.
+     */
+    public function testPositionalArgumentsMapInOrder(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'app:copy', 'source.txt', 'target.txt', 'third'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: 'app:copy', actual: $input->getCommandName());
+        self::assertSame(
+            expected: ['source.txt', 'target.txt', 'third'],
+            actual: self::argumentValues($input->getArguments())
+        );
+    }
+
+    /**
+     * Options and positional arguments interleave without disturbing each other's order.
+     */
+    public function testOptionsAndArgumentsInterleave(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'app:copy', 'source.txt', '--force', 'target.txt', '-v'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(
+            expected: ['source.txt', 'target.txt'],
+            actual: self::argumentValues($input->getArguments())
+        );
+        self::assertSame(
+            expected: [['force', '', OptionType::LONG], ['v', '', OptionType::SHORT]],
+            actual: self::optionTuples($input->getOptions())
+        );
+    }
+
+    /**
+     * @param non-empty-string[]                      $args
+     * @param list<array{string, string, OptionType}> $expected
+     */
+    #[DataProvider('provideOptionSpellings')]
+    public function testOptionSpellingsMapOntoOptions(array $args, array $expected): void
+    {
+        $input = InputFactory::fromGlobals($args, self::DEFAULT_CALLER, self::DEFAULT_COMMAND);
+
+        self::assertSame(expected: 'cmd', actual: $input->getCommandName());
+        self::assertSame(expected: $expected, actual: self::optionTuples($input->getOptions()));
+    }
+
+    /**
+     * @param non-empty-string[] $args
+     * @param class-string       $expected
+     */
+    #[DataProvider('provideRejectedSpellings')]
+    public function testRejectedSpellingsThrow(array $args, string $expected): void
+    {
+        $this->expectException($expected);
+
+        InputFactory::fromGlobals($args, self::DEFAULT_CALLER, self::DEFAULT_COMMAND);
+    }
+
+    /**
+     * hasValue() reflects whether a value was spelled out.
+     */
+    public function testOptionValuePresenceMapsFromSpelling(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '--with=value', '--without'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        [$with, $without] = array_values($input->getOptions());
+
+        self::assertTrue($with->hasValue());
+        self::assertSame(expected: 'value', actual: $with->getValue());
+        self::assertFalse($without->hasValue());
+        self::assertSame(expected: '', actual: $without->getValue());
+    }
+
+    /**
+     * A repeated option is preserved once per occurrence and looked up by name.
+     */
+    public function testRepeatedOptionsAreAllRetrievable(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '--tag=one', '--tag=two', '--other=x'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertTrue($input->hasOption('tag'));
+        self::assertTrue($input->hasOption('other'));
+        self::assertFalse($input->hasOption('missing'));
+        self::assertSame(expected: [], actual: $input->getOption('missing'));
+
+        $tags = array_values($input->getOption('tag'));
+
+        self::assertCount(expectedCount: 2, haystack: $tags);
+        self::assertSame(expected: 'one', actual: $tags[0]->getValue());
+        self::assertSame(expected: 'two', actual: $tags[1]->getValue());
+    }
+
+    /**
+     * An option spelled before the command name consumes that slot, so the default
+     * command name stands and the later bare token becomes a positional argument.
+     */
+    public function testOptionBeforeCommandNameLeavesTheDefaultCommandName(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', '--verbose', 'app:version'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: self::DEFAULT_COMMAND, actual: $input->getCommandName());
+        self::assertSame(expected: ['app:version'], actual: self::argumentValues($input->getArguments()));
+        self::assertTrue($input->hasOption('verbose'));
+    }
+
+    /**
+     * A space-separated option value is not attached to the option — it lands as a
+     * positional argument, so only the `--opt=value` spelling carries a value.
+     */
+    public function testSpaceSeparatedOptionValueBecomesAnArgument(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '--name', 'value'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: ['value'], actual: self::argumentValues($input->getArguments()));
+        self::assertSame(
+            expected: [['name', '', OptionType::LONG]],
+            actual: self::optionTuples($input->getOptions())
+        );
+    }
+}

--- a/tests/Tests/Functional/Http/Message/Request/RequestMappingTest.php
+++ b/tests/Tests/Functional/Http/Message/Request/RequestMappingTest.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Functional\Http\Message\Request;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Valkyrja\Http\Message\Constant\HeaderName;
+use Valkyrja\Http\Message\Enum\ProtocolVersion;
+use Valkyrja\Http\Message\Enum\RequestMethod;
+use Valkyrja\Http\Message\File\Collection\Contract\UploadedFileCollectionContract;
+use Valkyrja\Http\Message\File\Contract\UploadedFileContract;
+use Valkyrja\Http\Message\File\Enum\UploadError;
+use Valkyrja\Http\Message\Header\Collection\HeaderCollection;
+use Valkyrja\Http\Message\Header\Header;
+use Valkyrja\Http\Message\Param\Contract\ParamCollectionContract;
+use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Message\Request\ServerRequest;
+use Valkyrja\Http\Message\Stream\Stream;
+use Valkyrja\Http\Message\Uri\Enum\Scheme;
+use Valkyrja\Http\Message\Uri\Uri;
+use Valkyrja\Tests\Functional\Abstract\TestCase;
+
+use function array_intersect;
+use function array_keys;
+use function array_values;
+
+/**
+ * Message-mapping fidelity for an incoming HTTP request.
+ *
+ * Asserts that raw request inputs — the $_SERVER superglobal, query, parsed
+ * body, cookies, and uploaded files — land on the framework's own
+ * ServerRequest object exactly as supplied, independent of routing.
+ */
+final class RequestMappingTest extends TestCase
+{
+    /**
+     * Every method the RequestMethod enum defines.
+     *
+     * @return array<string, array{RequestMethod}>
+     */
+    public static function provideRequestMethods(): array
+    {
+        $methods = [];
+
+        foreach (RequestMethod::cases() as $case) {
+            $methods[$case->value] = [$case];
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @return array<string, array{string, ProtocolVersion}>
+     */
+    public static function provideProtocolVersions(): array
+    {
+        return [
+            'bare 1.0'     => ['1.0', ProtocolVersion::V1],
+            'bare 1.1'     => ['1.1', ProtocolVersion::V1_1],
+            'bare 2'       => ['2', ProtocolVersion::V2],
+            'bare 3'       => ['3', ProtocolVersion::V3],
+            'prefixed 1.0' => ['HTTP/1.0', ProtocolVersion::V1],
+            'prefixed 1.1' => ['HTTP/1.1', ProtocolVersion::V1_1],
+            'prefixed 2'   => ['HTTP/2', ProtocolVersion::V2],
+            'prefixed 3'   => ['HTTP/3', ProtocolVersion::V3],
+        ];
+    }
+
+    /**
+     * @return array<string, array{array<string, string>, string}>
+     */
+    public static function provideRequestTargets(): array
+    {
+        return [
+            'plain path'      => [['REQUEST_URI' => '/users/42'], '/users/42'],
+            'path with query' => [
+                ['REQUEST_URI' => '/users/42?page=2', 'QUERY_STRING' => 'page=2'],
+                '/users/42?page=2',
+            ],
+            'root path'       => [['REQUEST_URI' => '/'], '/'],
+            'no request uri'  => [[], '/'],
+            'x rewrite url'   => [['HTTP_X_REWRITE_URL' => '/rewritten'], '/rewritten'],
+            'x original url'  => [['HTTP_X_ORIGINAL_URL' => '/original'], '/original'],
+            'unencoded url'   => [
+                ['IIS_WasUrlRewritten' => '1', 'UNENCODED_URL' => '/unencoded'],
+                '/unencoded',
+            ],
+            'orig path info'  => [['ORIG_PATH_INFO' => '/orig'], '/orig'],
+            'absolute uri'    => [['REQUEST_URI' => 'https://example.com/absolute'], '/absolute'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{array<string, string>, string, int}>
+     */
+    public static function provideIpv6HostsAndPorts(): array
+    {
+        return [
+            'last address digit mistaken for a port' => [
+                ['SERVER_NAME' => '[fe80::1]', 'SERVER_ADDR' => 'fe80::1', 'SERVER_PORT' => '1', 'HTTPS' => 'on'],
+                '[fe80::1]',
+                0,
+            ],
+            'explicit port kept'                     => [
+                ['SERVER_NAME' => '[fe80::1]', 'SERVER_ADDR' => 'fe80::1', 'SERVER_PORT' => '8080', 'HTTPS' => 'on'],
+                '[fe80::1]',
+                8080,
+            ],
+            'absent port falls back to 80'           => [
+                ['SERVER_NAME' => '[fe80::1]', 'SERVER_ADDR' => 'fe80::1', 'HTTPS' => 'on'],
+                '[fe80::1]',
+                80,
+            ],
+            'server name is not ipv6 shaped'         => [
+                ['SERVER_NAME' => 'plain.test', 'SERVER_ADDR' => 'fe80::1', 'SERVER_PORT' => '8080', 'HTTPS' => 'on'],
+                'plain.test',
+                8080,
+            ],
+            'ipv6 server name without an address'    => [
+                ['SERVER_NAME' => '[fe80::1]', 'SERVER_PORT' => '8080', 'HTTPS' => 'on'],
+                '[fe80::1]',
+                8080,
+            ],
+        ];
+    }
+
+    /**
+     * Every request method spelled in $_SERVER maps onto the enum case.
+     */
+    #[DataProvider('provideRequestMethods')]
+    public function testRequestMethodMapsFromServer(RequestMethod $method): void
+    {
+        $request = RequestFactory::fromGlobals(server: ['REQUEST_METHOD' => $method->value]);
+
+        self::assertSame(expected: $method, actual: $request->getMethod());
+        self::assertSame(expected: $method->value, actual: $request->getMethod()->value);
+    }
+
+    /**
+     * The method survives a withMethod() round-trip without touching the original.
+     */
+    #[DataProvider('provideRequestMethods')]
+    public function testRequestMethodRoundTrips(RequestMethod $method): void
+    {
+        $request = new ServerRequest();
+        $new     = $request->withMethod($method);
+
+        self::assertSame(expected: RequestMethod::GET, actual: $request->getMethod());
+        self::assertSame(expected: $method, actual: $new->getMethod());
+    }
+
+    #[DataProvider('provideProtocolVersions')]
+    public function testProtocolVersionMapsFromServer(string $serverProtocol, ProtocolVersion $expected): void
+    {
+        $request = RequestFactory::fromGlobals(server: ['SERVER_PROTOCOL' => $serverProtocol]);
+
+        self::assertSame(expected: $expected, actual: $request->getProtocolVersion());
+    }
+
+    /**
+     * @param array<string, string> $server
+     */
+    #[DataProvider('provideRequestTargets')]
+    public function testRequestTargetMapsFromServer(array $server, string $expected): void
+    {
+        $request = RequestFactory::fromGlobals(server: $server);
+
+        self::assertSame(expected: $expected, actual: $request->getRequestTarget());
+    }
+
+    /**
+     * A fully populated $_SERVER maps onto every URI component.
+     */
+    public function testUriMapsFromServer(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'REQUEST_METHOD' => RequestMethod::POST->value,
+                'REQUEST_URI'    => '/users/42/edit?page=2&sort=name',
+                'QUERY_STRING'   => 'page=2&sort=name',
+                'HTTPS'          => 'on',
+                'HTTP_HOST'      => 'example.com:8443',
+            ]
+        );
+
+        $uri = $request->getUri();
+
+        self::assertSame(expected: Scheme::HTTPS, actual: $uri->getScheme());
+        self::assertTrue($uri->isSecure());
+        self::assertSame(expected: 'example.com', actual: $uri->getHost());
+        self::assertSame(expected: 8443, actual: $uri->getPort());
+        self::assertSame(expected: '/users/42/edit', actual: $uri->getPath());
+        self::assertSame(expected: 'page=2&sort=name', actual: $uri->getQuery());
+        self::assertSame(expected: '', actual: $uri->getFragment());
+        self::assertSame(
+            expected: 'https://example.com:8443/users/42/edit?page=2&sort=name',
+            actual: $uri->__toString()
+        );
+        self::assertSame(expected: '/users/42/edit?page=2&sort=name', actual: $request->getRequestTarget());
+    }
+
+    /**
+     * The scheme falls back to http, and the host comes from SERVER_NAME/SERVER_PORT
+     * when no Host header is present.
+     */
+    public function testUriFallsBackToServerNameAndPort(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'SERVER_NAME' => 'internal.test',
+                'SERVER_PORT' => '8080',
+                'REQUEST_URI' => '/health',
+            ]
+        );
+
+        $uri = $request->getUri();
+
+        self::assertSame(expected: Scheme::HTTP, actual: $uri->getScheme());
+        self::assertFalse($uri->isSecure());
+        self::assertSame(expected: 'internal.test', actual: $uri->getHost());
+        self::assertSame(expected: 8080, actual: $uri->getPort());
+    }
+
+    /**
+     * A fragment is carried through when the request target has no query string.
+     */
+    public function testUriFragmentMapsFromServer(): void
+    {
+        $request = RequestFactory::fromGlobals(server: ['REQUEST_URI' => '/docs#section']);
+
+        self::assertSame(expected: '/docs', actual: $request->getUri()->getPath());
+        self::assertSame(expected: 'section', actual: $request->getUri()->getFragment());
+    }
+
+    /**
+     * A SERVER_NAME that looks like a bracketed IPv6 address is re-derived from
+     * SERVER_ADDR, and the port is reinterpreted when the address' last digit was
+     * mistaken for one (as Safari on Windows reports it).
+     *
+     * @param array<string, string> $server
+     */
+    #[DataProvider('provideIpv6HostsAndPorts')]
+    public function testIpv6HostAndPortMapFromServer(array $server, string $expectedHost, int $expectedPort): void
+    {
+        $uri = RequestFactory::fromGlobals(server: $server)->getUri();
+
+        self::assertSame(expected: $expectedHost, actual: $uri->getHost());
+        self::assertSame(expected: $expectedPort, actual: $uri->getPort());
+    }
+
+    /**
+     * The X-Forwarded-Proto header promotes the scheme to https.
+     */
+    public function testUriSchemeMapsFromForwardedProtoHeader(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'HTTP_X_FORWARDED_PROTO' => Scheme::HTTPS->value,
+                'HTTP_HOST'              => 'example.com',
+            ]
+        );
+
+        self::assertSame(expected: Scheme::HTTPS, actual: $request->getUri()->getScheme());
+    }
+
+    /**
+     * Query params — including nested arrays — map onto the query collection verbatim.
+     */
+    public function testQueryParamsMapFromGlobals(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            query: [
+                'page'   => '2',
+                'sort'   => 'name',
+                'filter' => ['status' => 'active', 'tags' => ['a', 'b']],
+            ]
+        );
+
+        $query = $request->getQueryParams();
+
+        self::assertTrue($query->has('page'));
+        self::assertSame(expected: '2', actual: $query->get('page'));
+        self::assertSame(expected: 'name', actual: $query->get('sort'));
+
+        $filter = $query->get('filter');
+
+        self::assertInstanceOf(expected: ParamCollectionContract::class, actual: $filter);
+        self::assertSame(expected: 'active', actual: $filter->get('status'));
+
+        $tags = $filter->get('tags');
+
+        self::assertInstanceOf(expected: ParamCollectionContract::class, actual: $tags);
+        self::assertSame(expected: 'a', actual: $tags->get(0));
+        self::assertSame(expected: 'b', actual: $tags->get(1));
+
+        // A missing query param reads back as an empty string, never null.
+        self::assertSame(expected: '', actual: $query->get('missing'));
+        self::assertFalse($query->has('missing'));
+    }
+
+    /**
+     * The parsed body maps onto the parsed-body collection verbatim.
+     */
+    public function testParsedBodyMapsFromGlobals(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            body: [
+                'title' => 'hello',
+                'count' => '3',
+                'meta'  => ['draft' => 'yes'],
+            ]
+        );
+
+        $parsedBody = $request->getParsedBody();
+
+        self::assertTrue($parsedBody->has('title'));
+        self::assertSame(expected: 'hello', actual: $parsedBody->get('title'));
+        self::assertSame(expected: '3', actual: $parsedBody->get('count'));
+
+        $meta = $parsedBody->get('meta');
+
+        self::assertInstanceOf(expected: ParamCollectionContract::class, actual: $meta);
+        self::assertSame(expected: 'yes', actual: $meta->get('draft'));
+
+        // A missing parsed-body param reads back as an empty string, never null.
+        self::assertSame(expected: '', actual: $parsedBody->get('missing'));
+        self::assertFalse($parsedBody->has('missing'));
+    }
+
+    /**
+     * Server params are exposed exactly as supplied.
+     */
+    public function testServerParamsMapFromGlobals(): void
+    {
+        $server = [
+            'REQUEST_METHOD'  => RequestMethod::PUT->value,
+            'REQUEST_URI'     => '/resource',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+        ];
+
+        $request = RequestFactory::fromGlobals(server: $server);
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame(expected: RequestMethod::PUT->value, actual: $serverParams->get('REQUEST_METHOD'));
+        self::assertSame(expected: '/resource', actual: $serverParams->get('REQUEST_URI'));
+        self::assertSame(expected: 'HTTP/1.1', actual: $serverParams->get('SERVER_PROTOCOL'));
+    }
+
+    /**
+     * HTTP_* and CONTENT_* server entries become normalized headers, and lookups
+     * are case-insensitive.
+     */
+    public function testHeadersMapFromServerCaseInsensitively(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: [
+                'HTTP_HOST'         => 'example.com',
+                'HTTP_ACCEPT'       => 'text/html',
+                'HTTP_X_CUSTOM_KEY' => 'custom-value',
+                'CONTENT_TYPE'      => 'application/json',
+                'CONTENT_LENGTH'    => '42',
+                'NOT_A_HEADER'      => 'ignored',
+            ]
+        );
+
+        $headers = $request->getHeaders();
+
+        // Header names are normalized to lower case, in the order they appear in $_SERVER.
+        // Only the marshalled names are compared: the environment may contribute an
+        // extra `authorization` entry when apache_request_headers() is available.
+        $expectedNames = ['host', 'accept', 'x-custom-key', 'content-type', 'content-length'];
+        $actualNames   = array_intersect(array_keys($headers->getAll()), $expectedNames);
+
+        self::assertSame(expected: $expectedNames, actual: array_values($actualNames));
+
+        self::assertTrue($headers->has('Accept'));
+        self::assertTrue($headers->has('ACCEPT'));
+        self::assertTrue($headers->has('accept'));
+        self::assertSame(expected: 'text/html', actual: $headers->getHeaderLine('AcCePt'));
+        self::assertSame(expected: 'custom-value', actual: $headers->getHeaderLine('X-Custom-Key'));
+        self::assertSame(expected: 'application/json', actual: $headers->getHeaderLine('Content-Type'));
+        self::assertSame(expected: '42', actual: $headers->getHeaderLine('CONTENT-LENGTH'));
+
+        self::assertFalse($headers->has('Not-A-Header'));
+        self::assertSame(expected: '', actual: $headers->getHeaderLine('Not-A-Header'));
+    }
+
+    /**
+     * A multi-value header exposes each value and joins them for the header line.
+     */
+    public function testMultiValueHeadersMapOntoRequest(): void
+    {
+        $request = new ServerRequest(
+            headers: new HeaderCollection(
+                new Header('Accept', 'text/html', 'application/xhtml+xml'),
+                new Header('X-Trace', 'first')
+            )
+        );
+
+        $accept = $request->getHeaders()->get('accept');
+
+        self::assertSame(expected: 'Accept', actual: $accept->getName());
+        self::assertSame(expected: 'accept', actual: $accept->getNormalizedName());
+        self::assertSame(expected: ['text/html', 'application/xhtml+xml'], actual: $accept->getValues());
+        self::assertSame(expected: 'text/html, application/xhtml+xml', actual: $accept->getHeaderLine());
+        self::assertCount(expectedCount: 2, haystack: $accept);
+
+        $added = $request->withHeaders(
+            $request->getHeaders()->withAddedHeaders(new Header('ACCEPT', 'application/json'))
+        );
+
+        self::assertSame(
+            expected: 'text/html, application/xhtml+xml, application/json',
+            actual: $added->getHeaders()->getHeaderLine('accept')
+        );
+
+        $overridden = $request->withHeaders(
+            $request->getHeaders()->withHeader(new Header('ACCEPT', 'text/plain'))
+        );
+
+        self::assertSame(expected: 'text/plain', actual: $overridden->getHeaders()->getHeaderLine('Accept'));
+        self::assertSame(expected: 'first', actual: $overridden->getHeaders()->getHeaderLine('x-trace'));
+    }
+
+    /**
+     * A comma-delimited raw header line splits into discrete values.
+     */
+    public function testHeaderFromRawValueSplitsOnCommas(): void
+    {
+        $header = Header::fromValue('X-Multi: a,b,c');
+
+        self::assertSame(expected: 'X-Multi', actual: $header->getName());
+        self::assertSame(expected: 'x-multi', actual: $header->getNormalizedName());
+        self::assertSame(expected: 'a, b, c', actual: $header->getHeaderLine());
+        self::assertSame(expected: 'X-Multi: a, b, c', actual: $header->__toString());
+    }
+
+    /**
+     * Cookies are parsed out of the Cookie header when none are supplied directly.
+     */
+    public function testCookiesMapFromCookieHeader(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: ['HTTP_COOKIE' => 'sid=abc123; theme=dark']
+        );
+
+        $cookies = $request->getCookieParams();
+
+        self::assertSame(expected: ['sid' => 'abc123', 'theme' => 'dark'], actual: $cookies->getAll());
+        self::assertSame(expected: 'abc123', actual: $cookies->get('sid'));
+        self::assertSame(expected: 'dark', actual: $cookies->get('theme'));
+        self::assertSame(expected: 'sid=abc123; theme=dark', actual: $request->getHeaders()->getHeaderLine('Cookie'));
+    }
+
+    /**
+     * Explicitly supplied cookies take precedence over the Cookie header.
+     */
+    public function testExplicitCookiesTakePrecedenceOverHeader(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: ['HTTP_COOKIE' => 'sid=from-header'],
+            cookies: ['sid' => 'from-globals']
+        );
+
+        self::assertSame(expected: 'from-globals', actual: $request->getCookieParams()->get('sid'));
+    }
+
+    /**
+     * A flat $_FILES spec maps onto an uploaded-file object.
+     */
+    public function testUploadedFilesMapFromFlatSpec(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            files: [
+                'avatar' => [
+                    'tmp_name' => '/tmp/php-upload-avatar',
+                    'size'     => 1024,
+                    'error'    => UploadError::OK->value,
+                    'name'     => 'avatar.png',
+                    'type'     => 'image/png',
+                ],
+            ]
+        );
+
+        $file = $request->getUploadedFiles()->get('avatar');
+
+        self::assertInstanceOf(expected: UploadedFileContract::class, actual: $file);
+        self::assertSame(expected: 'avatar.png', actual: $file->getClientFilename());
+        self::assertSame(expected: 'image/png', actual: $file->getClientMediaType());
+        self::assertSame(expected: 1024, actual: $file->getSize());
+        self::assertSame(expected: UploadError::OK, actual: $file->getError());
+        self::assertTrue($file->hasSize());
+        self::assertTrue($file->hasClientFilename());
+        self::assertTrue($file->hasClientMediaType());
+    }
+
+    /**
+     * A nested $_FILES spec maps onto a nested uploaded-file collection.
+     */
+    public function testUploadedFilesMapFromNestedSpec(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            files: [
+                'documents' => [
+                    'tmp_name' => ['/tmp/one', '/tmp/two'],
+                    'size'     => [10, 20],
+                    'error'    => [UploadError::OK->value, UploadError::NO_FILE->value],
+                    'name'     => ['one.txt', 'two.txt'],
+                    'type'     => ['text/plain', 'text/plain'],
+                ],
+            ]
+        );
+
+        $documents = $request->getUploadedFiles()->get('documents');
+
+        self::assertInstanceOf(expected: UploadedFileCollectionContract::class, actual: $documents);
+
+        $first  = $documents->get(0);
+        $second = $documents->get(1);
+
+        self::assertInstanceOf(expected: UploadedFileContract::class, actual: $first);
+        self::assertInstanceOf(expected: UploadedFileContract::class, actual: $second);
+        self::assertSame(expected: 'one.txt', actual: $first->getClientFilename());
+        self::assertSame(expected: 10, actual: $first->getSize());
+        self::assertSame(expected: UploadError::OK, actual: $first->getError());
+        self::assertSame(expected: 'two.txt', actual: $second->getClientFilename());
+        self::assertSame(expected: 20, actual: $second->getSize());
+        self::assertSame(expected: UploadError::NO_FILE, actual: $second->getError());
+    }
+
+    /**
+     * Swapping the URI re-derives the Host header from it — unless the caller asks
+     * to preserve an existing Host header, or the new URI carries no host at all.
+     */
+    public function testWithUriReDerivesTheHostHeader(): void
+    {
+        $request = new ServerRequest(
+            uri: new Uri(host: 'original.test'),
+            headers: new HeaderCollection(new Header(HeaderName::HOST, 'original.test'))
+        );
+
+        // A host without a port yields a bare host header.
+        $swapped = $request->withUri(new Uri(host: 'new.test'));
+
+        self::assertSame(expected: 'new.test', actual: $swapped->getHeaders()->getHeaderLine(HeaderName::HOST));
+
+        // A host with a port yields host:port.
+        $withPort = $request->withUri(new Uri(host: 'new.test', port: 9090));
+
+        self::assertSame(expected: 'new.test:9090', actual: $withPort->getHeaders()->getHeaderLine(HeaderName::HOST));
+
+        // preserveHost keeps the existing header even though the URI changed.
+        $preserved = $request->withUri(new Uri(host: 'new.test'), preserveHost: true);
+
+        self::assertSame(expected: 'original.test', actual: $preserved->getHeaders()->getHeaderLine(HeaderName::HOST));
+        self::assertSame(expected: 'new.test', actual: $preserved->getUri()->getHost());
+
+        // A URI with no host leaves the existing header alone.
+        $hostless = $request->withUri(new Uri());
+
+        self::assertSame(expected: 'original.test', actual: $hostless->getHeaders()->getHeaderLine(HeaderName::HOST));
+        self::assertSame(expected: '', actual: $hostless->getUri()->getHost());
+
+        // preserveHost with no header to preserve still derives one from the URI.
+        $noHeader = new ServerRequest()->withUri(new Uri(host: 'new.test', port: 8080), preserveHost: true);
+
+        self::assertSame(expected: 'new.test:8080', actual: $noHeader->getHeaders()->getHeaderLine(HeaderName::HOST));
+
+        // The original is untouched throughout.
+        self::assertSame(expected: 'original.test', actual: $request->getHeaders()->getHeaderLine(HeaderName::HOST));
+    }
+
+    /**
+     * The body stream is exposed verbatim and rewinds for repeat reads.
+     */
+    public function testBodyContentsMapOntoRequest(): void
+    {
+        $body = new Stream();
+        $body->write('{"title":"hello"}');
+        $body->rewind();
+
+        $request = new ServerRequest(body: $body);
+
+        self::assertSame(expected: '{"title":"hello"}', actual: $request->getBody()->getContents());
+        self::assertSame(expected: '{"title":"hello"}', actual: $request->getBody()->__toString());
+
+        $replacement = new Stream();
+        $replacement->write('replaced');
+        $replacement->rewind();
+
+        $new = $request->withBody($replacement);
+
+        self::assertSame(expected: 'replaced', actual: $new->getBody()->__toString());
+        self::assertSame(expected: '{"title":"hello"}', actual: $request->getBody()->__toString());
+    }
+
+    /**
+     * An empty $_SERVER yields the documented defaults.
+     */
+    public function testDefaultsWhenNothingIsSupplied(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            server: [],
+            query: [],
+            body: [],
+            cookies: [],
+            files: []
+        );
+
+        self::assertSame(expected: RequestMethod::GET, actual: $request->getMethod());
+        self::assertSame(expected: ProtocolVersion::V1_1, actual: $request->getProtocolVersion());
+        self::assertSame(expected: '/', actual: $request->getRequestTarget());
+        self::assertSame(expected: '', actual: $request->getUri()->getHost());
+        self::assertSame(expected: [], actual: $request->getQueryParams()->getAll());
+        self::assertSame(expected: [], actual: $request->getParsedBody()->getAll());
+        self::assertSame(expected: [], actual: $request->getCookieParams()->getAll());
+        self::assertSame(expected: [], actual: $request->getUploadedFiles()->getAll());
+        self::assertSame(expected: [], actual: $request->getAttributes()->getAll());
+    }
+
+    /**
+     * The X-Requested-With header drives the XHR flag.
+     */
+    public function testXmlHttpRequestFlagMapsFromHeader(): void
+    {
+        $xhr   = RequestFactory::fromGlobals(server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        $plain = RequestFactory::fromGlobals(server: []);
+
+        self::assertTrue($xhr->isXmlHttpRequest());
+        self::assertFalse($plain->isXmlHttpRequest());
+    }
+}

--- a/tests/Tests/Functional/Http/Message/Response/ResponseMappingTest.php
+++ b/tests/Tests/Functional/Http/Message/Response/ResponseMappingTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Functional\Http\Message\Response;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Valkyrja\Http\Message\Enum\ProtocolVersion;
+use Valkyrja\Http\Message\Enum\StatusCode;
+use Valkyrja\Http\Message\Enum\StatusText;
+use Valkyrja\Http\Message\Header\Collection\HeaderCollection;
+use Valkyrja\Http\Message\Header\Header;
+use Valkyrja\Http\Message\Response\Response;
+use Valkyrja\Http\Message\Stream\Stream;
+use Valkyrja\Tests\Functional\Abstract\TestCase;
+
+use function array_keys;
+use function constant;
+
+/**
+ * Message-mapping fidelity for an outgoing HTTP response.
+ *
+ * Asserts that a status code, headers, and body land on the framework's own
+ * Response object and round-trip back out unchanged — including the
+ * StatusCode to reason-phrase mapping across every defined code.
+ */
+final class ResponseMappingTest extends TestCase
+{
+    /**
+     * Every status code the StatusCode enum defines.
+     *
+     * @return array<string, array{StatusCode}>
+     */
+    public static function provideStatusCodes(): array
+    {
+        $codes = [];
+
+        foreach (StatusCode::cases() as $case) {
+            $codes[$case->name] = [$case];
+        }
+
+        return $codes;
+    }
+
+    /**
+     * A representative code from each status class.
+     *
+     * @return array<string, array{StatusCode, int, string}>
+     */
+    public static function provideRepresentativeStatusCodes(): array
+    {
+        return [
+            'informational' => [StatusCode::CONTINUE, 100, 'Continue'],
+            'successful'    => [StatusCode::OK, 200, 'OK'],
+            'created'       => [StatusCode::CREATED, 201, 'Created'],
+            'no content'    => [StatusCode::NO_CONTENT, 204, 'No Content'],
+            'redirection'   => [StatusCode::MOVED_PERMANENTLY, 301, 'Moved Permanently'],
+            'not modified'  => [StatusCode::NOT_MODIFIED, 304, 'Not Modified'],
+            'client error'  => [StatusCode::NOT_FOUND, 404, 'Not Found'],
+            'unauthorized'  => [StatusCode::UNAUTHORIZED, 401, 'Unauthorized'],
+            'server error'  => [StatusCode::INTERNAL_SERVER_ERROR, 500, 'Internal Server Error'],
+        ];
+    }
+
+    /**
+     * Every status code resolves to the reason phrase its StatusText twin defines.
+     */
+    #[DataProvider('provideStatusCodes')]
+    public function testEveryStatusCodeMapsToItsReasonPhrase(StatusCode $statusCode): void
+    {
+        /** @var StatusText $statusText */
+        $statusText = constant(StatusText::class . '::' . $statusCode->name);
+
+        $response = new Response(statusCode: $statusCode);
+
+        self::assertSame(expected: $statusCode, actual: $response->getStatusCode());
+        self::assertSame(expected: $statusCode->value, actual: $response->getStatusCode()->value);
+        self::assertSame(expected: $statusText->value, actual: $statusCode->asPhrase());
+        self::assertSame(expected: $statusText->value, actual: $response->getReasonPhrase());
+    }
+
+    /**
+     * A representative code from each class exposes its numeric code and phrase.
+     */
+    #[DataProvider('provideRepresentativeStatusCodes')]
+    public function testRepresentativeStatusCodesMapOntoResponse(
+        StatusCode $statusCode,
+        int $expectedCode,
+        string $expectedPhrase
+    ): void {
+        $response = new Response(statusCode: $statusCode);
+
+        self::assertSame(expected: $expectedCode, actual: $response->getStatusCode()->value);
+        self::assertSame(expected: $expectedCode, actual: $statusCode->code());
+        self::assertSame(expected: $expectedPhrase, actual: $response->getReasonPhrase());
+    }
+
+    /**
+     * Swapping the status code swaps the reason phrase with it.
+     */
+    public function testWithStatusCodeUpdatesTheReasonPhrase(): void
+    {
+        $response = new Response(statusCode: StatusCode::OK);
+        $new      = $response->withStatusCode(StatusCode::IM_USED);
+
+        self::assertSame(expected: StatusCode::OK, actual: $response->getStatusCode());
+        self::assertSame(expected: 'OK', actual: $response->getReasonPhrase());
+        self::assertSame(expected: StatusCode::IM_USED, actual: $new->getStatusCode());
+        self::assertSame(expected: 'IM Used', actual: $new->getReasonPhrase());
+    }
+
+    /**
+     * A custom reason phrase overrides the default without changing the code,
+     * and an empty phrase restores the code's own phrase.
+     */
+    public function testCustomReasonPhraseOverridesTheDefault(): void
+    {
+        $response = new Response(statusCode: StatusCode::NOT_FOUND);
+        $custom   = $response->withReasonPhrase('Totally Missing');
+        $restored = $custom->withReasonPhrase('');
+
+        self::assertSame(expected: 'Not Found', actual: $response->getReasonPhrase());
+        self::assertSame(expected: 'Totally Missing', actual: $custom->getReasonPhrase());
+        self::assertSame(expected: StatusCode::NOT_FOUND, actual: $custom->getStatusCode());
+        self::assertSame(expected: 'Not Found', actual: $restored->getReasonPhrase());
+    }
+
+    /**
+     * Headers supplied to the constructor round-trip back out, case-insensitively.
+     */
+    public function testHeadersRoundTripThroughTheResponse(): void
+    {
+        $response = new Response(
+            statusCode: StatusCode::OK,
+            headers: new HeaderCollection(
+                new Header('Content-Type', 'application/json'),
+                new Header('Cache-Control', 'no-cache', 'no-store')
+            )
+        );
+
+        $headers = $response->getHeaders();
+
+        self::assertSame(expected: ['content-type', 'cache-control'], actual: array_keys($headers->getAll()));
+        self::assertTrue($headers->has('CONTENT-TYPE'));
+        self::assertSame(expected: 'application/json', actual: $headers->getHeaderLine('Content-Type'));
+        self::assertSame(expected: 'no-cache, no-store', actual: $headers->getHeaderLine('cache-control'));
+        self::assertSame(
+            expected: ['no-cache', 'no-store'],
+            actual: $headers->get('Cache-Control')->getValues()
+        );
+
+        $added = $response->withHeaders(
+            $headers->withAddedHeaders(new Header('CACHE-CONTROL', 'must-revalidate'))
+        );
+
+        self::assertSame(
+            expected: 'no-cache, no-store, must-revalidate',
+            actual: $added->getHeaders()->getHeaderLine('Cache-Control')
+        );
+        self::assertSame(expected: 'no-cache, no-store', actual: $response->getHeaders()->getHeaderLine('Cache-Control'));
+
+        $removed = $response->withHeaders($headers->withoutHeader('Content-Type'));
+
+        self::assertFalse($removed->getHeaders()->has('content-type'));
+        self::assertSame(expected: '', actual: $removed->getHeaders()->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * A body supplied to the constructor round-trips back out unchanged.
+     */
+    public function testBodyRoundTripsThroughTheConstructor(): void
+    {
+        $body = new Stream();
+        $body->write('{"ok":true}');
+        $body->rewind();
+
+        $response = new Response($body, StatusCode::OK);
+
+        self::assertSame(expected: '{"ok":true}', actual: $response->getBody()->getContents());
+        self::assertSame(expected: '{"ok":true}', actual: $response->getBody()->__toString());
+    }
+
+    /**
+     * The create() factory writes content into a rewound body stream.
+     */
+    public function testBodyRoundTripsThroughTheCreateFactory(): void
+    {
+        $response = Response::create(
+            content: 'plain content',
+            statusCode: StatusCode::ACCEPTED,
+            headers: new HeaderCollection(new Header('X-Trace', 'abc'))
+        );
+
+        self::assertSame(expected: 'plain content', actual: $response->getBody()->getContents());
+        self::assertSame(expected: StatusCode::ACCEPTED, actual: $response->getStatusCode());
+        self::assertSame(expected: 'Accepted', actual: $response->getReasonPhrase());
+        self::assertSame(expected: 'abc', actual: $response->getHeaders()->getHeaderLine('x-trace'));
+    }
+
+    /**
+     * create() with no arguments yields an empty 200 response.
+     */
+    public function testCreateDefaults(): void
+    {
+        $response = Response::create();
+
+        self::assertSame(expected: '', actual: $response->getBody()->getContents());
+        self::assertSame(expected: StatusCode::OK, actual: $response->getStatusCode());
+        self::assertSame(expected: 'OK', actual: $response->getReasonPhrase());
+        self::assertSame(expected: [], actual: $response->getHeaders()->getAll());
+        self::assertSame(expected: ProtocolVersion::V1_1, actual: $response->getProtocolVersion());
+    }
+
+    /**
+     * Swapping the body leaves the original response untouched.
+     */
+    public function testWithBodyLeavesTheOriginalUntouched(): void
+    {
+        $response = Response::create(content: 'original');
+
+        $replacement = new Stream();
+        $replacement->write('replacement');
+        $replacement->rewind();
+
+        $new = $response->withBody($replacement);
+
+        self::assertSame(expected: 'replacement', actual: $new->getBody()->__toString());
+        self::assertSame(expected: 'original', actual: $response->getBody()->__toString());
+    }
+
+    /**
+     * The protocol version round-trips.
+     */
+    public function testProtocolVersionRoundTrips(): void
+    {
+        $response = Response::create();
+        $new      = $response->withProtocolVersion(ProtocolVersion::V2);
+
+        self::assertSame(expected: ProtocolVersion::V1_1, actual: $response->getProtocolVersion());
+        self::assertSame(expected: ProtocolVersion::V2, actual: $new->getProtocolVersion());
+    }
+}


### PR DESCRIPTION
# Description

Adds framework-level **message-mapping fidelity** tests: proof that an incoming
HTTP request, an outgoing HTTP response, and an incoming CLI command map
faithfully onto the framework's own objects — independent of routing.

This implements the architecture TODO item
["Framework tests — request & command mapping fidelity"](https://github.com/valkyrjaio/architecture/pull/65)
for PHP, the reference implementation. Java and TypeScript will mirror these
tests against the same class/method names.

A mapping defect — a dropped header, a wrong reason phrase, a mis-parsed option —
is invisible to route-matching tests. The Java and TypeScript starter-app
entry/worker end-to-end work surfaced exactly this class of bug, caught far from
the source. These tests shift that coverage left: sooner, and closer to where the
mapping actually lives.

The tests are **functional** (they exercise the factory → collection → message
pipeline as a whole, roughly ten units per assertion path) rather than unit, and
they assert observable behavior only, through the public API. Nothing in `src/`
changed — this is a test-only PR.

Coverage: line coverage stays at **100%** (9707/9707 lines, 554/554 classes,
2884/2884 methods). Branch coverage rises — `Request::withUri()` and
`MarshalUriFactory::marshalIpv6HostAndPort()` were the two branch gaps inside the
message-mapping surface, and both are now closed. The repo's overall branch
figure remains short of 100% because of gaps outside this PR's surface
(`Container`, `Orm`, `Mail`, `Type`, `View`, `Cli\Interaction\Message\Answer`,
`Cli\Interaction\Output\Output`, and SAPI-dependent guards such as
`UploadedFileFactory::isValidSapiEnvironmentForUploads()`, which no test can
reach under the CLI SAPI). That shortfall is pre-existing and untouched here — a
test-only PR cannot lower it, since the phpunit `<source>` block covers `src`
only.

## What is asserted

**HTTP request** — `RequestFactory::fromGlobals()` and the `ServerRequest`
constructor:

- **method** — a data-provider matrix over every `RequestMethod` case
  (`GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`,
  `PATCH`, `ANY`), for both `$_SERVER['REQUEST_METHOD']` mapping and a
  `withMethod()` round-trip
- **request target / URI** — a matrix over every source `MarshalUriFactory`
  consults (`REQUEST_URI`, `HTTP_X_REWRITE_URL`, `HTTP_X_ORIGINAL_URL`,
  `UNENCODED_URL`, `ORIG_PATH_INFO`, absolute URI, and the `/` fallback), plus
  scheme/host/port/path/query/fragment, the `SERVER_NAME`/`SERVER_PORT`
  fallback, the `X-Forwarded-Proto` promotion to https, and the misinterpreted
  bracketed-IPv6 `SERVER_NAME`/`SERVER_ADDR` reinterpretation
- **Host header re-derivation** — `withUri()` across all four of its paths:
  host-only, host with port, `preserveHost` with an existing header,
  `preserveHost` without one, and a host-less URI
- **protocol version** — a matrix over bare and `HTTP/`-prefixed spellings
- **headers** — `HTTP_*` and `CONTENT_*` marshalling, lower-case normalization,
  case-insensitive `has()`/`get()`/`getHeaderLine()`, multi-value headers
  (per-value access, `', '` joining, add-vs-override semantics), and
  comma-splitting via `Header::fromValue()`
- **query params / parsed body** — including nested arrays becoming nested
  collections, and the empty-string (not `null`) miss semantics
- **cookies** — parsed from the `Cookie` header, and the explicit-argument
  precedence over that header
- **uploaded files** — flat and nested `$_FILES` specs
- **body** — stream contents and `withBody()` immutability
- **server params**, **attributes**, and the `X-Requested-With` XHR flag

**HTTP response** — the `Response` constructor and `Response::create()`:

- **every** `StatusCode` case (62) resolves to the phrase its `StatusText` twin
  defines, and the response exposes it via `getReasonPhrase()`
- a representative code per status class asserts the numeric code and phrase
- `withStatusCode()` swaps the phrase with the code; a custom
  `withReasonPhrase()` overrides it without touching the code; an empty phrase
  restores the code's own phrase
- headers round-trip case-insensitively, including multi-value add-vs-override
  and removal; body round-trips through both the constructor and `create()`;
  protocol version round-trips

**CLI input** — `InputFactory::fromGlobals()`:

- caller and command name from argv, and the supplied defaults when argv is bare
- positional arguments in argv order, interleaved with options
- a data-provider matrix over every option spelling: `--opt=value`, `--opt`,
  `--opt=`, `-o`, `-o=value`, bundled short flags (`-abc` → three options), a
  repeated option, and a mixed long/short run
- `hasValue()` / `getValue()` / `getType()` per option, and `getOption()` /
  `hasOption()` lookup across repeated options
- the spellings the factory **rejects**, each with its exact exception

## Behaviors pinned that are worth a second look

These are current behavior, asserted as-is rather than changed — flagged here so
Java/TypeScript mirror them deliberately, and so they can be triaged separately:

- **`--` is not a terminator.** `InputFactory` treats it as an option with an
  empty name and throws `CliInteractionInvalidNonEmptyValueException` (as does a
  bare `-`).
- **A space-separated option value is not attached to its option.**
  `--name value` yields an option `name` with **no** value plus a positional
  argument `value`; only `--name=value` carries a value.
- **An option before the command name consumes that slot.**
  `valkyrja --verbose app:version` leaves the command name at its default and
  makes `app:version` a positional argument.
- **An option value containing `=` is truncated.** `--expr=a=b` yields the value
  `a`, because `OptionFactory` takes only `explode('=', $arg)[1]`.
- **`ParsedBodyParamCollection`/`QueryParamCollection` accept non-string
  scalars but cannot return them.** `fromArray(['count' => 3])` stores the int,
  and the narrowed `get(): …|string` return type then raises a `TypeError`. Real
  `$_POST`/`$_GET` values are always strings or arrays, so the tests use string
  values; the accept/return mismatch is left untouched here.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/Tests/Functional/Http/Message/Request/RequestMappingTest.php`** — new: raw `$_SERVER`/query/body/cookie/file inputs mapped onto `ServerRequest`, with data-provider matrices for the request-method, request-target, protocol-version, and IPv6 host/port axes, plus `withUri()` Host-header re-derivation.
- **`tests/Tests/Functional/Http/Message/Response/ResponseMappingTest.php`** — new: status code, reason phrase (every `StatusCode` case plus a custom-phrase override), headers, and body round-tripping through `Response`.
- **`tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php`** — new: argv-style arrays mapped onto `Input`/`Argument`/`Option`, covering every supported option spelling and each rejected one.
