### PR TITLE
[Cli] Split an option arg on the first equals only so values keep theirs

### DIFF
--- a/src/Valkyrja/Cli/Interaction/Option/Factory/OptionFactory.php
+++ b/src/Valkyrja/Cli/Interaction/Option/Factory/OptionFactory.php
@@ -38,7 +38,9 @@ abstract class OptionFactory
 
         $type = self::getOptionType($arg);
 
-        $parts = explode('=', $arg);
+        // Split on the first `=` only, so a value that itself contains one survives intact
+        // (`--expr=a=b` yields `a=b`, not `a`).
+        $parts = explode('=', $arg, 2);
         $name  = trim($parts[0], '- ');
         $value = $parts[1] ?? '';
 

--- a/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
+++ b/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
@@ -93,7 +93,7 @@ final class InputMappingTest extends TestCase
             ],
             'value containing equals' => [
                 ['valkyrja', 'cmd', '--expr=a=b'],
-                [['expr', 'a', OptionType::LONG]],
+                [['expr', 'a=b', OptionType::LONG]],
             ],
         ];
     }


### PR DESCRIPTION
# Description

Fixes an option value that itself contains an `=` being silently truncated.

`OptionFactory::fromArg()` split the raw arg with `explode('=', $arg)` — no limit — and took
`$parts[1]`. For `--expr=a=b` that yields `a`, dropping everything from the second `=` onward. The
option's value should be everything after the *first* `=`, so the fix is a limit of 2.

This surfaced while porting the message-mapping fidelity tests to Java
(valkyrjaio/valkyrja-java#55). Java's `OptionFactory` already used `split("=", 2)` and produced
`a=b`, so the two ports disagreed. Retaining the whole value is the faithful mapping — an option
value is opaque to the parser — so PHP is the side that was wrong, and the Java port is left as-is.

The `value containing equals` case in `InputMappingTest` (added in #932) pinned the old truncating
behavior, so its expectation is updated to `a=b` in the same commit as the fix.

Sibling PRs:

- **Java** — valkyrjaio/valkyrja-java#55 (message-mapping fidelity tests; asserts `a=b`)
- **Architecture** — valkyrjaio/architecture#68 (per-language CLI argv conventions)

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`Cli/Interaction/Option/Factory/OptionFactory.php`** — split the raw arg on the first `=` only
  (`explode('=', $arg, 2)`) so a value containing an `=` survives intact instead of being truncated
  at the second one.
- **`tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php`** — updated the
  `value containing equals` expectation from `a` to `a=b` to match.
