### PR TITLE
[CI] Close reachable branch coverage gaps found by path coverage

### DIFF
--- a/tests/Tests/Unit/Cli/Interaction/Output/OutputTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Output/OutputTest.php
@@ -218,6 +218,31 @@ final class OutputTest extends TestCase
         self::assertEmpty($outputContents);
     }
 
+    /**
+     * Quiet mode only suppresses output on a successful exit code. With a failing exit
+     * code the message is still written, so the operator sees why the run failed.
+     */
+    public function testQuietOutputStillWritesMessagesOnFailureExitCode(): void
+    {
+        $message = new Message('text');
+
+        $quietSuccess = new Output(isQuiet: true, exitCode: ExitCode::SUCCESS)
+            ->withAddedMessage($message);
+        $quietFailure = new Output(isQuiet: true, exitCode: ExitCode::ERROR)
+            ->withAddedMessage($message);
+
+        ob_start();
+        $quietSuccess->writeMessages();
+        $quietSuccessContents = ob_get_clean();
+
+        ob_start();
+        $quietFailure->writeMessages();
+        $quietFailureContents = ob_get_clean();
+
+        self::assertEmpty($quietSuccessContents);
+        self::assertStringContainsString('text', (string) $quietFailureContents);
+    }
+
     public function testReAskQuestionOnInvalidAnswer(): void
     {
         $callableCalled = false;

--- a/tests/Tests/Unit/Container/Manager/ContainerTest.php
+++ b/tests/Tests/Unit/Container/Manager/ContainerTest.php
@@ -18,6 +18,7 @@ use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Enum\InvalidReferenceMode;
 use Valkyrja\Container\Manager\Container;
 use Valkyrja\Container\Throwable\Exception\Abstract\ContainerInvalidArgumentException;
+use Valkyrja\Container\Throwable\Exception\ContainerInvalidReferenceException;
 use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
 use Valkyrja\Dispatch\Provider\DispatchServiceProvider;
 use Valkyrja\Tests\Fixtures\Container\ServiceFixture;
@@ -106,6 +107,29 @@ final class ContainerTest extends TestCase
         // A bound singleton should return the same instance each time it is retrieved
         self::assertSame($service, $container->get($id));
         self::assertSame($service, $container->getSingleton($id));
+    }
+
+    /**
+     * A singleton binding whose callable does not produce an object must not be cached as
+     * an instance; the resolution yields null and getSingleton() reports the service as
+     * not found. Reaching this defensive guard needs a synthetic factory, since a
+     * well-behaved one always returns an object.
+     */
+    public function testGetSingletonWithNonObjectFromBindingThrows(): void
+    {
+        $container = $this->container;
+        $id        = SingletonFixture::class;
+
+        /** @psalm-suppress InvalidArgument, MixedArgumentTypeCoercion */
+        $container->bindSingleton($id, static fn (): null => null);
+
+        self::assertTrue($container->isSingletonBinding($id));
+        // Nothing was cached as an instance, so the singleton is still unresolved.
+        self::assertFalse($container->isSingletonInstance($id));
+
+        $this->expectException(ContainerInvalidReferenceException::class);
+
+        $container->getSingleton($id);
     }
 
     public function testSetSingleton(): void

--- a/tests/Tests/Unit/Container/Manager/NativeChildContainerTest.php
+++ b/tests/Tests/Unit/Container/Manager/NativeChildContainerTest.php
@@ -135,6 +135,16 @@ final class NativeChildContainerTest extends TestCase
         self::assertFalse($this->parent->has(DispatcherContract::class));
     }
 
+    /**
+     * With the service registered in neither the child nor the parent, every arm of the
+     * short-circuit chain in has() is evaluated: the child and parent callbacks, then
+     * the singleton, service, and alias lookups.
+     */
+    public function testHasReturnsFalseWhenRegisteredInNeitherChildNorParent(): void
+    {
+        self::assertFalse($this->child->has(DispatcherContract::class));
+    }
+
     public function testIsPublishedFromParent(): void
     {
         $this->parent->bind(ServiceFixture::class, [ServiceFixture::class, 'make']);

--- a/tests/Tests/Unit/Dispatch/Factory/DispatchFactoryTest.php
+++ b/tests/Tests/Unit/Dispatch/Factory/DispatchFactoryTest.php
@@ -25,8 +25,11 @@ use Valkyrja\Dispatch\Data\ConstantDispatch;
 use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Dispatch\Data\PropertyDispatch;
 use Valkyrja\Dispatch\Factory\DispatchFactory;
+use Valkyrja\Dispatch\Throwable\Exception\DispatchInvalidReflectionFunctionException;
 use Valkyrja\Tests\Fixtures\Dispatch\InvalidDispatcherFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+use function is_callable;
 
 /**
  * Test the DispatchFactory.
@@ -92,5 +95,20 @@ final class DispatchFactoryTest extends TestCase
         self::assertSame($class, $classDispatch->getClass());
 
         self::assertSame($callable, $callableDispatch->getCallable());
+    }
+
+    /**
+     * A closure's reflection name is a synthetic `{closure:...}` label rather than a
+     * callable string, so it cannot be turned into a CallableDispatch.
+     */
+    public function testFromReflectionThrowsForNonCallableFunctionName(): void
+    {
+        $reflection = new ReflectionFunction(static fn (): null => null);
+
+        self::assertFalse(is_callable($reflection->getName()));
+
+        $this->expectException(DispatchInvalidReflectionFunctionException::class);
+
+        DispatchFactory::fromReflection($reflection);
     }
 }

--- a/tests/Tests/Unit/Type/Object/Support/ClsTest.php
+++ b/tests/Tests/Unit/Type/Object/Support/ClsTest.php
@@ -30,6 +30,13 @@ final class ClsTest extends TestCase
         Cls::validateInherits(self::class, stdClass::class);
     }
 
+    public function testValidateInheritsDoesNotThrowForInheritedClass(): void
+    {
+        Cls::validateInherits(self::class, TestCase::class);
+
+        self::assertTrue(true); // If we reach here, no exception was thrown
+    }
+
     public function testInherits(): void
     {
         self::assertFalse(Cls::inherits(self::class, stdClass::class));
@@ -41,6 +48,13 @@ final class ClsTest extends TestCase
         $this->expectException(InvalidObjectPropertyProvidedException::class);
 
         Cls::validateHasProperty(self::class, 'test');
+    }
+
+    public function testValidateHasPropertyDoesNotThrowForExistingProperty(): void
+    {
+        Cls::validateHasProperty(self::class, 'validProperty');
+
+        self::assertTrue(true); // If we reach here, no exception was thrown
     }
 
     public function testHasProperty(): void

--- a/tests/Tests/Unit/Type/Ulid/Factory/UlidFactoryTest.php
+++ b/tests/Tests/Unit/Type/Ulid/Factory/UlidFactoryTest.php
@@ -160,6 +160,35 @@ final class UlidFactoryTest extends TestCase
     }
 
     /**
+     * Test doesTimeMatch() when a date time is passed in and the time it produces is
+     * exactly the previously stored time. Neither `$time > static::$time` nor
+     * `$time !== static::$time` holds, so the whole condition is false even though a
+     * date time was given — the remaining branch of the `$dateTime !== null && ...`
+     * half of the condition.
+     *
+     * @throws Exception
+     */
+    public function testGenerateWithDateTimeMatchingStoredTime(): void
+    {
+        $dateTime = new DateTime('2024-01-15 12:30:45.123456');
+
+        // Store exactly the time this date time produces.
+        UlidFactoryFixture::setTime($dateTime->format('Uv'));
+
+        // Random bytes not at max -> areAllRandomBytesMax() false -> else branch.
+        UlidFactoryFixture::setRandomBytes([
+            1 => 100,
+            2 => 200,
+            3 => 300,
+            4 => 400,
+        ]);
+
+        $ulid = UlidFactoryFixture::generate($dateTime);
+
+        self::assertTrue(UlidFactoryFixture::isValid($ulid));
+    }
+
+    /**
      * Test getTime with negative timestamp throws exception (lines 140-144).
      */
     public function testGetTimeWithNegativeTimestamp(): void

--- a/tests/Tests/Unit/View/Renderer/PhpRendererTest.php
+++ b/tests/Tests/Unit/View/Renderer/PhpRendererTest.php
@@ -134,6 +134,29 @@ final class PhpRendererTest extends TestCase
         self::assertTrue($exceptionThrown, 'Expected RuntimeException was not thrown');
     }
 
+    /**
+     * An empty template name appends nothing to the templates directory, so the resolved
+     * path is the directory itself and is reported as a missing template.
+     */
+    public function testRenderFileWithEmptyTemplateResolvesToDirectory(): void
+    {
+        $renderer        = new PhpRenderer(self::TEMPLATES_DIR);
+        $exceptionThrown = false;
+
+        try {
+            $renderer->renderFile('');
+        } catch (ViewInvalidPathException $e) {
+            $exceptionThrown = true;
+            self::assertStringContainsString('Path does not exist at', $e->getMessage());
+        } finally {
+            while (ob_get_level() > 1) {
+                ob_end_clean();
+            }
+        }
+
+        self::assertTrue($exceptionThrown, 'Expected ViewInvalidPathException was not thrown');
+    }
+
     public function testRenderFileWithConfiguredPath(): void
     {
         $renderer = new PhpRenderer(


### PR DESCRIPTION
# Description

Closes the reachable branch-coverage gaps surfaced by the path-coverage harness from #933, and
records what turned out not to be reachable at all.

Ten branches across seven files now execute that previously did not. Each was verified per-file
before and after by running that file's own shard under `--path-coverage`:

| File | Before | After |
|------|--------|-------|
| `Container/Manager/NativeChildContainer.php` | 29/32 | **32/32** |
| `Type/Object/Support/Cls.php` | 8/10 | **10/10** |
| `Container/Manager/Container.php` | 51/52 | **52/52** |
| `Cli/Interaction/Output/Output.php` | 37/38 | **38/38** |
| `Type/Ulid/Factory/UlidFactory.php` | 45/46 | **46/46** |
| `View/Renderer/PhpRenderer.php` | 22/23 | **23/23** |
| `Dispatch/Factory/DispatchFactory.php` | 13/16 | 14/16 |

These are real tests, not coverage padding. Both `Cls` validators were only ever exercised on their
throwing path, so nothing asserted they accept valid input; quiet `Output` had no test proving a
failing exit code still writes its message; and `NativeChildContainer::has()` was never called for a
service registered in neither the child nor the parent, so most of its lookup chain never ran.

## The reported gap was substantially larger than the real one

The merged report claimed 41 missing branches. Checking each file against its own shard — a single
process, so no merging — showed that **19 of those are already fully covered**:

| File | Merged claimed missing | Actual, in its own shard |
|------|------------------------|--------------------------|
| `Http/Routing/Processor/Processor.php` | 9 | **43/43 — 100%** |
| `Api/Manager/Api.php` | 4 | **24/24 — 100%** |
| `Http/Message/Request/Request.php` | 4 | **32/32 — 100%** |
| `Cli/Server/Provider/CliServerServiceProvider.php` | 2 | **22/22 — 100%** |

The merged report counts 52 executable branches for `Processor.php` where every individual shard
counts 43. Xdebug builds a different branch map for a function depending on whether it actually ran,
so merging shard data unions two incompatible maps and invents branches that nothing can execute.
This is the branch-level form of the `match`-line line-coverage artifact already documented in #933;
a follow-up corrects that documentation, which currently claims merged data is sound for finding
branch gaps.

## Branches that no test can reach

Three of the remaining gaps are not test gaps:

- **`Cli/Server/Support/Exiter.php`** — `static::$exit ? exit($code) : ...`. The `exit()` arm ends
  the process, so it cannot be executed from inside a test run.
- **`Dispatch/Factory/DispatchFactory.php`** (2) — the implicit fall-through of a `match (true)`
  whose five arms exhaustively cover the parameter's union type, so the `UnhandledMatchError` path
  is unreachable by construction.
- **`Type/Enum/Trait/JsonSerializable.php`** — a trait compiled into each using class. Run alone it
  reports 3/3; run with the full `Type` suite it reports 2/3, because a backed enum never executes
  `return $this->name` and a pure enum never executes `return $this->value`, and the per-class
  copies are conflated into one file entry. Adding tests lowers this number rather than raising it.

**100% branch coverage is therefore not attainable**, and a `REQUIRE_BRANCH=100` gate could never go
green. A threshold gate (or gating per shard rather than on merged data, which removes the 19-branch
artifact) is the workable option; that decision is left out of this PR.

Still open, and likely genuine: `Orm/Provider/OrmServiceProvider.php` (2), plus one each in
`GuzzleClient`, `UploadedFileFactory`, `ServerRequest`, `RequestHandler`, `MailServiceProvider` and
`Answer`.

## Verification

`phpunit` (5131 tests), `phpunit-coverage` (100% classes / methods / lines), `phpstan`, `psalm`,
`phparkitect`, `phpcodesniffer` and `phpcsfixer` + `phpcsfixer-check` all pass.

`rector-check` fails locally, but identically on an unmodified `26.x` with these changes stashed
(64 errors, all `System error: "phar://…/.worktrees/…/phpstan.phar/…" is not a file` pointing at a
deleted sibling worktree). It is a stale absolute path in the local environment, unrelated to this
change; CI runs it from a clean checkout.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/…/Container/Manager/NativeChildContainerTest.php`** — assert `has()` is false for a
  service registered in neither the child nor the parent, so every arm of its short-circuit chain
  (child callbacks, parent callbacks, singleton, service, alias) is evaluated.
- **`tests/…/Container/Manager/ContainerTest.php`** — a singleton binding whose callable yields a
  non-object is not cached as an instance and is reported as not found; reaches the defensive guard
  in `getSingletonWithoutChecks()` with a synthetic factory.
- **`tests/…/Type/Object/Support/ClsTest.php`** — assert `validateInherits()` and
  `validateHasProperty()` accept valid input without throwing; both previously only had
  exception tests.
- **`tests/…/Type/Ulid/Factory/UlidFactoryTest.php`** — generate with a date time whose time equals
  the stored time, covering the remaining half of the `$dateTime !== null && $time !== static::$time`
  condition in `doesTimeMatch()`.
- **`tests/…/Cli/Interaction/Output/OutputTest.php`** — quiet mode suppresses output on success but
  still writes on a failing exit code.
- **`tests/…/View/Renderer/PhpRendererTest.php`** — an empty template name resolves to the templates
  directory itself and is reported as a missing template.
- **`tests/…/Dispatch/Factory/DispatchFactoryTest.php`** — a closure's reflection name is a synthetic
  `{closure:…}` label rather than a callable string, so it cannot become a `CallableDispatch`.
