### PR TITLE
[Cli] Treat a bare double dash as the end-of-options marker and a lone dash as an operand

### DIFF
--- a/src/Valkyrja/Cli/Interaction/Input/Factory/InputFactory.php
+++ b/src/Valkyrja/Cli/Interaction/Input/Factory/InputFactory.php
@@ -23,20 +23,6 @@ use function str_starts_with;
 abstract class InputFactory
 {
     /**
-     * The POSIX end-of-options marker. Every arg after it is an operand.
-     *
-     * @var non-empty-string
-     */
-    public const string END_OF_OPTIONS = '--';
-
-    /**
-     * A lone dash, which names standard input by convention and is an operand, not an option.
-     *
-     * @var non-empty-string
-     */
-    public const string STDIN = '-';
-
-    /**
      * Create an input from given global variables.
      *
      * @param non-empty-string[] $args            The arguments
@@ -67,12 +53,12 @@ abstract class InputFactory
         foreach ($args as $key => $arg) {
             if ($key === 0) {
                 $applicationName = $arg;
-            } elseif (! $endOfOptions && $arg === self::END_OF_OPTIONS) {
+            } elseif (! $endOfOptions && $arg === '--') {
                 // POSIX end-of-options marker: the `--` itself is consumed, and every arg after
                 // it is an operand — never an option, however many dashes it starts with. A
                 // second `--` is therefore an ordinary operand.
                 $endOfOptions = true;
-            } elseif (! $endOfOptions && $arg !== self::STDIN && str_starts_with($arg, '-')) {
+            } elseif (! $endOfOptions && $arg !== '-' && str_starts_with($arg, '-')) {
                 // A lone `-` is an operand by convention (it names standard input), not an option.
                 $options = [
                     ...$options,

--- a/src/Valkyrja/Cli/Interaction/Input/Factory/InputFactory.php
+++ b/src/Valkyrja/Cli/Interaction/Input/Factory/InputFactory.php
@@ -23,6 +23,20 @@ use function str_starts_with;
 abstract class InputFactory
 {
     /**
+     * The POSIX end-of-options marker. Every arg after it is an operand.
+     *
+     * @var non-empty-string
+     */
+    public const string END_OF_OPTIONS = '--';
+
+    /**
+     * A lone dash, which names standard input by convention and is an operand, not an option.
+     *
+     * @var non-empty-string
+     */
+    public const string STDIN = '-';
+
+    /**
      * Create an input from given global variables.
      *
      * @param non-empty-string[] $args            The arguments
@@ -45,14 +59,21 @@ abstract class InputFactory
      */
     protected static function inputWithProperties(InputContract $input, array $args, string $applicationName, string $commandName): InputContract
     {
-        $arguments = [];
-        $options   = [];
+        $arguments    = [];
+        $options      = [];
+        $endOfOptions = false;
 
         /** @var non-empty-string $arg */
         foreach ($args as $key => $arg) {
             if ($key === 0) {
                 $applicationName = $arg;
-            } elseif (str_starts_with($arg, '-')) {
+            } elseif (! $endOfOptions && $arg === self::END_OF_OPTIONS) {
+                // POSIX end-of-options marker: the `--` itself is consumed, and every arg after
+                // it is an operand — never an option, however many dashes it starts with. A
+                // second `--` is therefore an ordinary operand.
+                $endOfOptions = true;
+            } elseif (! $endOfOptions && $arg !== self::STDIN && str_starts_with($arg, '-')) {
+                // A lone `-` is an operand by convention (it names standard input), not an option.
                 $options = [
                     ...$options,
                     ...OptionFactory::fromArg($arg),

--- a/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
+++ b/tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php
@@ -106,12 +106,8 @@ final class InputMappingTest extends TestCase
     public static function provideRejectedSpellings(): array
     {
         return [
-            'double dash terminator'   => [
-                ['valkyrja', 'cmd', '--'],
-                CliInteractionInvalidNonEmptyValueException::class,
-            ],
-            'single dash'              => [
-                ['valkyrja', 'cmd', '-'],
+            'empty long option name'   => [
+                ['valkyrja', 'cmd', '--=value'],
                 CliInteractionInvalidNonEmptyValueException::class,
             ],
             'bundled short with value' => [
@@ -329,5 +325,89 @@ final class InputMappingTest extends TestCase
             expected: [['name', '', OptionType::LONG]],
             actual: self::optionTuples($input->getOptions())
         );
+    }
+
+    /**
+     * A bare `--` ends option parsing: it is consumed, and everything after it is an
+     * operand no matter how many dashes it starts with.
+     */
+    public function testDoubleDashEndsOptionParsing(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '--real', '--', '--not-an-option', '-x', 'plain'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: 'cmd', actual: $input->getCommandName());
+        self::assertSame(
+            expected: ['--not-an-option', '-x', 'plain'],
+            actual: self::argumentValues($input->getArguments())
+        );
+        self::assertSame(
+            expected: [['real', '', OptionType::LONG]],
+            actual: self::optionTuples($input->getOptions())
+        );
+    }
+
+    /**
+     * The `--` itself never becomes an operand, but a second one does.
+     */
+    public function testSecondDoubleDashIsAnOperand(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '--', '--', 'tail'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: ['--', 'tail'], actual: self::argumentValues($input->getArguments()));
+        self::assertSame(expected: [], actual: $input->getOptions());
+    }
+
+    /**
+     * A lone `-` names standard input by convention, so it is an operand rather than an
+     * option — both before and after an end-of-options marker.
+     */
+    public function testLoneDashIsAnOperand(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', 'cmd', '-', '--verbose', '--', '-'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: ['-', '-'], actual: self::argumentValues($input->getArguments()));
+        self::assertSame(
+            expected: [['verbose', '', OptionType::LONG]],
+            actual: self::optionTuples($input->getOptions())
+        );
+    }
+
+    /**
+     * A `--` spelled in the command-name slot is still consumed, so the default command
+     * name stands and the following token becomes an operand.
+     */
+    public function testDoubleDashInTheCommandNameSlot(): void
+    {
+        $input = InputFactory::fromGlobals(
+            ['valkyrja', '--', 'app:version'],
+            self::DEFAULT_CALLER,
+            self::DEFAULT_COMMAND
+        );
+
+        self::assertSame(expected: self::DEFAULT_COMMAND, actual: $input->getCommandName());
+        self::assertSame(expected: ['app:version'], actual: self::argumentValues($input->getArguments()));
+    }
+
+    /**
+     * A lone `-` in the command-name slot fills it, since it is an operand.
+     */
+    public function testLoneDashInTheCommandNameSlot(): void
+    {
+        $input = InputFactory::fromGlobals(['valkyrja', '-'], self::DEFAULT_CALLER, self::DEFAULT_COMMAND);
+
+        self::assertSame(expected: '-', actual: $input->getCommandName());
+        self::assertSame(expected: [], actual: $input->getArguments());
     }
 }


### PR DESCRIPTION
# Description

Implements the POSIX end-of-options marker and fixes a lone `-` being rejected.

`InputFactory` decided option-vs-operand with a bare `startsWith('-')`, so two
conventional spellings were hard errors that took the whole command line with
them:

```
myapp cmd -- --not-an-option   → CliInteractionInvalidNonEmptyValueException
myapp cmd -- file.txt          → CliInteractionInvalidNonEmptyValueException
myapp cmd -                    → CliInteractionInvalidNonEmptyValueException
```

`--` reached `OptionFactory`, which stripped the dashes, got an empty name, and
threw. A bare `-` did the same.

**`--` is now the end-of-options marker.** It is consumed — it never becomes an
operand itself — and every arg after it is an operand no matter how many dashes
it starts with. This is how a caller passes a literal `--verbose` as data, or a
filename that begins with a dash. A *second* `--` is therefore an ordinary
operand, since option parsing has already ended.

**A lone `-` is now an operand.** By universal Unix convention (POSIX Utility
Syntax Guidelines) a single dash names standard input — `cat -`, `sort file -`,
`tar -xf -`. It is an operand, not an option. What "standard input" means is the
command's business; the parser's job is only to stop treating it as an option.

Positional semantics are unchanged: the command-name slot still works exactly as
before, so a `--` spelled in that slot is consumed and the default command name
stands (the same way an option spelled there already behaved), while a lone `-`
in that slot fills it, because it is an operand.

Handing `--` or `-` directly to `OptionFactory` still throws — that is correct at
that level, and those unit tests are unchanged. Only `InputFactory`, which decides
what is an option in the first place, changed.

Found via the request/command mapping-fidelity tests, which pinned both spellings
as current behavior and flagged them as looking like defects rather than intent.
Confirmed as defects, and fixed here across every port.

Sibling PRs (cross-language, same change):

- **PHP** (reference) — https://github.com/valkyrjaio/valkyrja-php/pull/938
- **Java** — https://github.com/valkyrjaio/valkyrja-java/pull/57
- **TypeScript** — https://github.com/valkyrjaio/valkyrja-ts/pull/94

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Cli/Interaction/Input/Factory/InputFactory.php`** — added `END_OF_OPTIONS` and `STDIN` constants; the arg loop now tracks an `$endOfOptions` flag, consumes the first bare `--`, and skips the option branch for a lone `-` so both land as operands.
- **`tests/Tests/Functional/Cli/Interaction/Input/InputMappingTest.php`** — replaced the two rejection cases that pinned `--` and `-` as errors with an `--=value` case (which still has an empty option name), and added five tests: the marker ending option parsing, a second `--` as an operand, a lone `-` as an operand before and after the marker, and both spellings landing in the command-name slot.
