### PR TITLE
[CI] Close the remaining reachable branch coverage gaps

### DIFF
--- a/tests/Tests/Fixtures/Env/OrmMysqlStrictEngineEnvFixture.php
+++ b/tests/Tests/Fixtures/Env/OrmMysqlStrictEngineEnvFixture.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Env;
+
+use Valkyrja\Application\Env\Env;
+
+/**
+ * Env with the optional MySQL strict mode and storage engine set, which default to null.
+ */
+final class OrmMysqlStrictEngineEnvFixture extends Env
+{
+    /** @var bool|null */
+    public const bool|null ORM_MYSQL_STRICT = true;
+    /** @var non-empty-string|null */
+    public const string|null ORM_MYSQL_ENGINE = 'InnoDB';
+}

--- a/tests/Tests/Unit/Cli/Interaction/Message/AnswerTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Message/AnswerTest.php
@@ -19,6 +19,7 @@ use Valkyrja\Cli\Interaction\Throwable\Exception\CliInteractionNoValidationCalla
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 use function str_contains;
+use function str_starts_with;
 
 /**
  * Test the ErrorMessage class.
@@ -171,5 +172,25 @@ final class AnswerTest extends TestCase
         self::assertFalse($message2->withUserResponse('text3')->isValidResponse());
         self::assertTrue($message2->withUserResponse('text4')->isValidResponse());
         self::assertTrue($message2->withUserResponse('text5')->isValidResponse());
+    }
+
+    /**
+     * With both an allowed-response list and a validation callable, a response outside the
+     * list is still valid when the callable accepts it.
+     */
+    public function testValidResponseFromCallableWhenNotInAllowedResponses(): void
+    {
+        $message = new Answer(
+            defaultResponse: 'yes',
+            validationCallable: static fn (string $response): bool => str_starts_with($response, 'maybe'),
+            allowedResponses: ['yes', 'no']
+        );
+
+        // In the allowed list.
+        self::assertTrue($message->withUserResponse('no')->isValidResponse());
+        // Not in the allowed list, but the callable accepts it.
+        self::assertTrue($message->withUserResponse('maybe so')->isValidResponse());
+        // Neither in the allowed list nor accepted by the callable.
+        self::assertFalse($message->withUserResponse('nope')->isValidResponse());
     }
 }

--- a/tests/Tests/Unit/Http/Client/Manager/GuzzleClientTest.php
+++ b/tests/Tests/Unit/Http/Client/Manager/GuzzleClientTest.php
@@ -25,6 +25,8 @@ use Valkyrja\Http\Message\Header\Factory\PsrHeaderFactory;
 use Valkyrja\Http\Message\Header\Header;
 use Valkyrja\Http\Message\Param\CookieParamCollection;
 use Valkyrja\Http\Message\Param\ParsedBodyParamCollection;
+use Valkyrja\Http\Message\Param\ParsedJsonParamCollection;
+use Valkyrja\Http\Message\Request\JsonServerRequest;
 use Valkyrja\Http\Message\Request\ServerRequest;
 use Valkyrja\Http\Message\Response\Factory\ResponseFactory;
 use Valkyrja\Http\Message\Response\Response;
@@ -95,6 +97,53 @@ final class GuzzleClientTest extends TestCase
         self::assertInstanceOf(Response::class, $response);
         self::assertSame($contents, $response->getBody()->getContents());
         self::assertSame('value', $response->getHeaders()->getHeaderLine('header'));
+        self::assertSame(StatusCode::OK, $response->getStatusCode());
+    }
+
+    /**
+     * A JSON request that carries parsed JSON is sent as JSON, so its parsed body must not
+     * also be attached as form params.
+     */
+    public function testSendJsonRequestWithParsedJsonOmitsFormParams(): void
+    {
+        $contents  = 'test';
+        $stringUri = 'https://example.com/';
+
+        $guzzle       = $this->createMock(Client::class);
+        $psr7Response = $this->createMock(ResponseInterface::class);
+        $psr7Body     = $this->createMock(StreamInterface::class);
+
+        $body = new Stream();
+        $body->write($contents);
+        $body->rewind();
+
+        $client  = new GuzzleClient(
+            client: $guzzle,
+            responseFactory: new ResponseFactory()
+        );
+        $request = new JsonServerRequest(
+            uri: UriFactory::fromString($stringUri),
+            body: $body,
+            parsedBody: ParsedBodyParamCollection::fromArray(['param' => 'value']),
+            parsedJson: ParsedJsonParamCollection::fromArray(['json' => 'value']),
+        );
+
+        $psr7Response->expects($this->once())->method('getHeaders')->willReturn([]);
+        $psr7Response->expects($this->once())->method('getStatusCode')->willReturn(200);
+        $psr7Response->expects($this->once())->method('getBody')->willReturn($psr7Body);
+        $psr7Body->expects($this->once())->method('getContents')->willReturn($contents);
+        $guzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                $stringUri,
+                self::logicalNot(self::arrayHasKey('form_params'))
+            )
+            ->willReturn($psr7Response);
+
+        $response = $client->sendRequest($request);
+
+        self::assertInstanceOf(Response::class, $response);
         self::assertSame(StatusCode::OK, $response->getStatusCode());
     }
 }

--- a/tests/Tests/Unit/Http/Message/Request/Psr/ServerRequestTest.php
+++ b/tests/Tests/Unit/Http/Message/Request/Psr/ServerRequestTest.php
@@ -107,6 +107,22 @@ final class ServerRequestTest extends TestCase
         self::assertSame($parsedBody2, $psrRequest2->getParsedBody());
     }
 
+    /**
+     * A null parsed body is normalized to an empty collection rather than cast, which is
+     * how PSR-7 signals the body has no parsed representation.
+     */
+    public function testParsedBodyWithNull(): void
+    {
+        $request    = new ServerRequest(parsedBody: ParsedBodyParamCollection::fromArray(['test' => 'value']));
+        $psrRequest = new PsrServerRequest($request);
+
+        $psrRequest2 = $psrRequest->withParsedBody(null);
+
+        self::assertNotSame($psrRequest, $psrRequest2);
+        self::assertSame(['test' => 'value'], $psrRequest->getParsedBody());
+        self::assertSame([], $psrRequest2->getParsedBody());
+    }
+
     public function testAttributes(): void
     {
         $attributes = ['test' => 'value'];

--- a/tests/Tests/Unit/Mail/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Mail/Provider/ServiceProviderTest.php
@@ -17,6 +17,7 @@ use Mailgun\HttpClient\HttpClientConfigurator;
 use Mailgun\Mailgun;
 use PHPMailer\PHPMailer\PHPMailer as PHPMailerClient;
 use PHPUnit\Framework\MockObject\Exception;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Log\Logger\Contract\LoggerContract;
 use Valkyrja\Mail\Mailer\Contract\MailerContract;
 use Valkyrja\Mail\Mailer\LogMailer;
@@ -108,7 +109,32 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $callback = new MailServiceProvider()->publishers()[PHPMailerClient::class];
         $callback($this->container);
 
-        self::assertInstanceOf(PHPMailerClient::class, $this->container->getSingleton(PHPMailerClient::class));
+        $mailer = $this->container->getSingleton(PHPMailerClient::class);
+
+        self::assertInstanceOf(PHPMailerClient::class, $mailer);
+        // Debug mode is off by default, so verbose SMTP output stays disabled.
+        self::assertSame(0, $mailer->SMTPDebug);
+    }
+
+    /**
+     * With the application in debug mode the mailer is given verbose SMTP output.
+     *
+     * @throws Exception
+     */
+    public function testPublishPhpMailerClientInDebugMode(): void
+    {
+        $app = self::createStub(ApplicationContract::class);
+        $app->method('getDebugMode')->willReturn(true);
+
+        $this->container->setSingleton(ApplicationContract::class, $app);
+
+        $callback = new MailServiceProvider()->publishers()[PHPMailerClient::class];
+        $callback($this->container);
+
+        $mailer = $this->container->getSingleton(PHPMailerClient::class);
+
+        self::assertInstanceOf(PHPMailerClient::class, $mailer);
+        self::assertSame(2, $mailer->SMTPDebug);
     }
 
     /**

--- a/tests/Tests/Unit/Orm/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Orm/Provider/ServiceProviderTest.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Tests\Unit\Orm\Provider;
 
 use PDO;
 use PHPUnit\Framework\MockObject\Exception;
+use Valkyrja\Application\Env\Env;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Orm\Entity\Abstract\Entity;
 use Valkyrja\Orm\Manager\Contract\ManagerContract;
@@ -25,6 +26,7 @@ use Valkyrja\Orm\Manager\SqliteManager;
 use Valkyrja\Orm\Provider\OrmServiceProvider;
 use Valkyrja\Orm\Repository\Repository;
 use Valkyrja\PhpUnit\Abstract\ServiceProviderTestCase;
+use Valkyrja\Tests\Fixtures\Env\OrmMysqlStrictEngineEnvFixture;
 use Valkyrja\Tests\Fixtures\Orm\PdoFixture;
 
 /**
@@ -70,6 +72,34 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $callback($this->container);
 
         self::assertInstanceOf(MysqlManager::class, $this->container->getSingleton(MysqlManager::class));
+    }
+
+    /**
+     * The optional strict mode and storage engine default to null and are then left out of
+     * the DSN entirely; when set they are appended to it.
+     */
+    public function testPublishMysqlManagerWithStrictAndEngine(): void
+    {
+        $this->container->setSingleton(Env::class, new OrmMysqlStrictEngineEnvFixture());
+
+        $dsn = null;
+
+        $this->container->bind(
+            PDO::class,
+            static function (ContainerContract $container, array $arguments) use (&$dsn): PDO {
+                $dsn = $arguments[0] ?? null;
+
+                return new PdoFixture('sqlite::memory:');
+            }
+        );
+
+        $callback = new OrmServiceProvider()->publishers()[MysqlManager::class];
+        $callback($this->container);
+
+        self::assertInstanceOf(MysqlManager::class, $this->container->getSingleton(MysqlManager::class));
+        self::assertIsString($dsn);
+        self::assertStringContainsString(';strict=1', $dsn);
+        self::assertStringContainsString(';engine=InnoDB', $dsn);
     }
 
     public function testPublishPgsqlManager(): void


### PR DESCRIPTION
# Description

Follow-up to #936, closing the branch-coverage gaps left open there. Five more branches now execute,
and the three that remain are shown to be unreachable rather than untested — so this finishes the
effort.

Each was verified by running the owning shard under `--path-coverage` before and after:

| File | Before | After |
|------|--------|-------|
| `Orm/Provider/OrmServiceProvider.php` | 14/16 | **16/16** |
| `Mail/Provider/MailServiceProvider.php` | 11/12 | **12/12** |
| `Http/Client/Manager/GuzzleClient.php` | 27/28 | **28/28** |
| `Http/Message/Request/Psr/ServerRequest.php` | 20/21 | **21/21** |

As in #936 these assert real behavior that nothing covered before: that the optional MySQL strict
mode and storage engine actually reach the DSN, that debug mode turns on verbose SMTP output, that a
JSON request carrying parsed JSON is not *also* sent with form params, and that a null parsed body
is normalized to an empty collection rather than cast.

## The last three branches cannot be reached

All three are environment- or invariant-determined, not missing tests:

- **`Http/Message/File/Factory/UploadedFileFactory.php`** —
  `! str_starts_with($sapi, 'cli') && ! str_starts_with($sapi, 'phpdbg')` where `$sapi` is the
  `PHP_SAPI` constant. Under PHPUnit `PHP_SAPI` is always `cli`, so the first operand is false and
  the second is never evaluated. `PHP_SAPI` cannot be changed at runtime.
- **`Http/Server/Handler/RequestHandler.php`** —
  `defined('PHP_OUTPUT_HANDLER_REMOVABLE') ? … : -1`. The comment above it explains the fallback is
  for HHVM 3.3; on any supported PHP the constant is always defined, so the `-1` arm is dead.
- **`Cli/Interaction/Message/Answer.php`** — the first clause of `isValidResponse()`,
  `$this->allowedResponses === [] && $validationCallable === null`. `allowedResponses` can never be
  empty: both the constructor and `withAllowedResponses()` append `$defaultResponse` when it is
  absent, so the second operand is never evaluated. This clause is dead code and is worth removing
  separately — doing so here would be a behavior change, not a test change.

Added together with the categories already documented in #937 (process-terminating arms, exhaustive
`match` fall-through, and traits compiled into several classes), every remaining reported branch gap
in the codebase is now accounted for as unreachable.

The `Answer` test in this PR does not close its branch — it stays because it covers a combination
nothing asserted before: a response outside the allowed list that the validation callable accepts.

## Verification

`phpunit` (5140 tests), `phpunit-coverage` (100% classes / methods / lines), `phpstan`, `psalm`,
`phparkitect`, `phpcodesniffer` and `phpcsfixer` + `phpcsfixer-check` all pass.

`rector-check` fails locally with the same pre-existing, environment-only error described in #936
(a stale absolute path to a deleted sibling worktree); it passed in CI on #936 and #937 and is
unrelated to these changes.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`tests/Tests/Fixtures/Env/OrmMysqlStrictEngineEnvFixture.php`** — new Env fixture setting the
  optional `ORM_MYSQL_STRICT` and `ORM_MYSQL_ENGINE`, which default to null.
- **`tests/…/Orm/Provider/ServiceProviderTest.php`** — publish the MySQL manager with that Env and
  capture the DSN handed to PDO, asserting `;strict=1` and `;engine=InnoDB` are appended.
- **`tests/…/Mail/Provider/ServiceProviderTest.php`** — publish the PHPMailer client with the
  application in debug mode and assert `SMTPDebug` is 2; also assert the existing non-debug test
  leaves it at 0.
- **`tests/…/Http/Client/Manager/GuzzleClientTest.php`** — a `JsonServerRequest` carrying parsed JSON
  is sent without `form_params`.
- **`tests/…/Http/Message/Request/Psr/ServerRequestTest.php`** — `withParsedBody(null)` yields an
  empty parsed body rather than casting null.
- **`tests/…/Cli/Interaction/Message/AnswerTest.php`** — a response outside the allowed list is still
  valid when the validation callable accepts it.
