### PR TITLE
[Dispatch] Fold the exhaustive match's last arm into default

### DIFF
--- a/src/Valkyrja/Dispatch/Factory/DispatchFactory.php
+++ b/src/Valkyrja/Dispatch/Factory/DispatchFactory.php
@@ -53,7 +53,11 @@ class DispatchFactory
             $reflection instanceof ReflectionClass         => new ClassDispatch(
                 class: $reflection->getName(),
             ),
-            $reflection instanceof ReflectionFunction      => new CallableDispatch(
+            // The parameter's union type makes ReflectionFunction the only
+            // remaining possibility, so this is `default` rather than a fifth
+            // `instanceof` arm -- an exhaustive match compiles in an
+            // UnhandledMatchError throw that no input can reach.
+            default                                        => new CallableDispatch(
                 callable: is_callable($name)
                     ? $name
                     : throw new DispatchInvalidReflectionFunctionException('ReflectionFunction has no valid callable'),


### PR DESCRIPTION
# Description

`DispatchFactory::fromReflection()` used a `match (true)` whose five `instanceof`
arms already covered every member of the parameter's union type. PHP still
compiles an implicit `UnhandledMatchError` throw into an exhaustive `match` with
no `default`, so two branches (and one path) in this method are unreachable by
any input — no test can close them.

This is one of the two known unreachable-branch categories recorded in the
architecture repo's `php/TODO.md`, and the prescribed remedy is to fold the last
arm into `default`. `ReflectionFunction` is the only type left once the four
preceding arms have been ruled out, so `default` is exactly equivalent in
behavior — the `is_callable()` guard and its
`DispatchInvalidReflectionFunctionException` are untouched.

Verified per-shard (never merged — Xdebug builds a different branch map for a
function depending on whether it ran, so merged shard data invents branches):

```
composer phpunit-path-coverage-shard Dispatch
```

**`src/Valkyrja/Dispatch/Factory/DispatchFactory.php`: branches 14/16 → 14/14,
paths 6/7 → 6/6.**

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Dispatch/Factory/DispatchFactory.php`** — replaced the final
  `$reflection instanceof ReflectionFunction` arm of `fromReflection()`'s
  `match (true)` with `default`, removing the unreachable `UnhandledMatchError`
  branch, and noted in a comment why the arm is spelled that way.
