### PR TITLE
[Http] Remove the dead HHVM output handler flag fallback

### DIFF
--- a/src/Valkyrja/Http/Server/Handler/RequestHandler.php
+++ b/src/Valkyrja/Http/Server/Handler/RequestHandler.php
@@ -36,7 +36,6 @@ use Valkyrja\Http\Routing\Dispatcher\Router;
 use Valkyrja\Http\Server\Handler\Contract\RequestHandlerContract;
 
 use function count;
-use function defined;
 use function fastcgi_finish_request;
 use function function_exists;
 use function in_array;
@@ -337,8 +336,7 @@ class RequestHandler implements RequestHandlerContract
     {
         $flushOrCleanFlag = $flush ? PHP_OUTPUT_HANDLER_FLUSHABLE : PHP_OUTPUT_HANDLER_CLEANABLE;
 
-        // PHP_OUTPUT_HANDLER_* are not defined on HHVM 3.3
-        return defined('PHP_OUTPUT_HANDLER_REMOVABLE') ? PHP_OUTPUT_HANDLER_REMOVABLE | $flushOrCleanFlag : -1;
+        return PHP_OUTPUT_HANDLER_REMOVABLE | $flushOrCleanFlag;
     }
 
     /**


### PR DESCRIPTION
# Description

`RequestHandler::getOutputDufferFlags()` guarded its return with
`defined('PHP_OUTPUT_HANDLER_REMOVABLE') ? … : -1`. The comment above it says why:
the `PHP_OUTPUT_HANDLER_*` constants were not defined on HHVM 3.3. The framework
requires PHP >= 8.4, where all three constants are always defined by the core
output-buffering extension, so the `-1` arm is dead code — no supported runtime
can take it, and no test can cover the branch.

Nothing consumes the `-1` sentinel: the return value is only ever assigned to
`$flags` in `closeOutputBuffers()` and used in the
`$flags === ($s['flags'] & $flags)` bitmask comparison, which has no special
handling for it. Dropping the ternary is therefore behavior-preserving on every
supported PHP version. The now-unused `use function defined;` import goes with
it.

Verified per-shard (never merged — Xdebug builds a different branch map for a
function depending on whether it ran, so merged shard data invents branches):

```
composer phpunit-path-coverage-shard Http
```

**`src/Valkyrja/Http/Server/Handler/RequestHandler.php`: branches 60/61 → 58/58,
paths 34/57 → 34/55.**

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Http/Server/Handler/RequestHandler.php`** — `getOutputDufferFlags()`
  now returns `PHP_OUTPUT_HANDLER_REMOVABLE | $flushOrCleanFlag` directly,
  dropping the unreachable HHVM 3.3 `-1` fallback, its comment, and the
  `use function defined;` import it needed.
