### PR TITLE
[Cli] Remove the unreachable empty allowed responses clause from Answer::isValidResponse

### DIFF
--- a/src/Valkyrja/Cli/Interaction/Message/Answer.php
+++ b/src/Valkyrja/Cli/Interaction/Message/Answer.php
@@ -226,8 +226,7 @@ class Answer extends Message implements AnswerContract
         $validationCallable = $this->validationCallable;
         $userResponse       = $this->userResponse;
 
-        return ($this->allowedResponses === [] && $validationCallable === null)
-            || in_array($userResponse, $this->allowedResponses, true)
+        return in_array($userResponse, $this->allowedResponses, true)
             || (
                 $validationCallable !== null
                 && $validationCallable($userResponse)

--- a/tests/Tests/Unit/Cli/Interaction/Message/AnswerTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Message/AnswerTest.php
@@ -175,6 +175,24 @@ final class AnswerTest extends TestCase
     }
 
     /**
+     * The allowed responses are never empty: the default response is always added to them, so an
+     * Answer given neither an allowed-response list nor a validation callable accepts only the
+     * default response.
+     */
+    public function testOnlyDefaultResponseIsValidWithoutAllowedResponsesOrCallable(): void
+    {
+        $message = new Answer(defaultResponse: 'yes');
+
+        self::assertSame(['yes'], $message->getAllowedResponses());
+        self::assertFalse($message->hasValidationCallable());
+        self::assertTrue($message->isValidResponse());
+        self::assertFalse($message->withUserResponse('no')->isValidResponse());
+
+        // Emptying the allowed responses is not possible; the default response is re-added.
+        self::assertSame(['yes'], $message->withAllowedResponses()->getAllowedResponses());
+    }
+
+    /**
      * With both an allowed-response list and a validation callable, a response outside the
      * list is still valid when the callable accepts it.
      */


### PR DESCRIPTION
# Description

`Answer::isValidResponse()` opened with a clause that can never evaluate to `true`:

```php
return ($this->allowedResponses === [] && $validationCallable === null)
    || in_array($userResponse, $this->allowedResponses, true)
    || ($validationCallable !== null && $validationCallable($userResponse));
```

`$this->allowedResponses` is never empty. The constructor appends `$defaultResponse` when it is
absent, and `withAllowedResponses()` does the same, so `$this->allowedResponses === []` is always
`false` and the `$validationCallable === null` half is never even evaluated. This was the one
branch in `Answer.php` that no test could reach (30/31 branches), found while closing branch
coverage gaps.

Both halves of that dead clause arrived in the same commit (`2c2583007`): _"Updating Answer to add
the default response to allowed responses, **and** fix validation if no allowed responses or
validation callback were set."_ Before it, `isValidResponse()` was `in_array(...) || callable(...)`,
so an `Answer` with neither an allowed list nor a callable could never validate — and
`QuestionWriter::askQuestion()` re-asks until the response is valid, so it looped forever. That one
bug was fixed two independent ways at once, and appending the default response fully resolves it on
its own. The fallback clause has been redundant ever since.

The empty-allowed-responses case was therefore never meant to mean "accept anything" — it meant
"such an `Answer` must be answerable." Accepting anything would also contradict `QuestionWriter`,
which prints the allowed responses to the user as their valid choices. The resulting semantics —
an `Answer` given neither an allowed-response list nor a validation callable accepts only the
default response — is already asserted by the existing `testValidationCallback()` and passes on
`26.x` today, so removing the clause is a no-op at runtime.

Verified against branch coverage: `GAPS=1 composer phpunit-path-coverage-parallel` reports
`Cli/Interaction/Message/Answer.php` at 96.77% (1 branch missing) on `26.x` and absent from the
list on this branch, with every other listed file unchanged. Full gate green (PHPStan, Psalm,
PHPArkitect, PHP CodeSniffer, PHP-CS-Fixer, Rector, PHPUnit — 5141 tests, 100% line coverage).

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Cli/Interaction/Message/Answer.php`** — removed the unreachable
  `$this->allowedResponses === [] && $validationCallable === null` clause from `isValidResponse()`,
  closing the file's last unreachable branch with no change in behavior.
- **`tests/Tests/Unit/Cli/Interaction/Message/AnswerTest.php`** — added
  `testOnlyDefaultResponseIsValidWithoutAllowedResponsesOrCallable()`, pinning the invariant that
  the allowed responses are never empty and that such an `Answer` accepts only the default
  response, so the semantics is asserted explicitly rather than incidentally.
