### PR TITLE
[Http] Add an overridable SAPI seam to UploadedFileFactory

### DIFF
--- a/src/Valkyrja/Http/Message/File/Factory/UploadedFileFactory.php
+++ b/src/Valkyrja/Http/Message/File/Factory/UploadedFileFactory.php
@@ -168,11 +168,23 @@ abstract class UploadedFileFactory
      */
     public static function isValidSapiEnvironmentForUploads(): bool
     {
-        $sapi = PHP_SAPI;
+        $sapi = static::getSapi();
 
         // If the PHP_SAPI value is not set to a CLI environment
         // and not a PHP debugger environment
         return ! str_starts_with($sapi, 'cli')
             && ! str_starts_with($sapi, 'phpdbg');
+    }
+
+    /**
+     * Get the SAPI name the current process is running under.
+     *
+     * A seam: PHP_SAPI is fixed for the lifetime of the process, so a test can
+     * only reach the non-CLI arms of isValidSapiEnvironmentForUploads() by
+     * overriding this.
+     */
+    protected static function getSapi(): string
+    {
+        return PHP_SAPI;
     }
 }

--- a/tests/Tests/Fixtures/Http/Message/File/UploadedFileFactorySapiFixture.php
+++ b/tests/Tests/Fixtures/Http/Message/File/UploadedFileFactorySapiFixture.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Http\Message\File;
+
+use Override;
+use Valkyrja\Http\Message\File\Factory\UploadedFileFactory;
+
+/**
+ * Drives the SAPI seam of UploadedFileFactory, so tests can exercise
+ * isValidSapiEnvironmentForUploads() for SAPIs other than the one PHPUnit
+ * itself runs under.
+ */
+final class UploadedFileFactorySapiFixture extends UploadedFileFactory
+{
+    /** The SAPI name to report to isValidSapiEnvironmentForUploads(). */
+    public static string $sapi = 'cli';
+
+    #[Override]
+    protected static function getSapi(): string
+    {
+        return self::$sapi;
+    }
+}

--- a/tests/Tests/Unit/Http/Message/File/Factory/UploadedFileFactoryTest.php
+++ b/tests/Tests/Unit/Http/Message/File/Factory/UploadedFileFactoryTest.php
@@ -13,15 +13,31 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Message\File\Factory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Valkyrja\Http\Message\File\Factory\UploadedFileFactory;
 use Valkyrja\Http\Message\File\Throwable\Exception\UploadedFileInvalidFilesArrayStructureException;
 use Valkyrja\Http\Message\File\Throwable\Exception\UploadedFileInvalidTmpNameException;
 use Valkyrja\Http\Message\File\Throwable\Exception\UploadedFileInvalidValueException;
 use Valkyrja\Http\Message\File\UploadedFile;
+use Valkyrja\Tests\Fixtures\Http\Message\File\UploadedFileFactorySapiFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 final class UploadedFileFactoryTest extends TestCase
 {
+    /**
+     * @return array<string, array{0: non-empty-string, 1: bool}>
+     */
+    public static function sapiProvider(): array
+    {
+        return [
+            'cli'            => ['cli', false],
+            'cli-server'     => ['cli-server', false],
+            'phpdbg'         => ['phpdbg', false],
+            'apache2handler' => ['apache2handler', true],
+            'fpm-fcgi'       => ['fpm-fcgi', true],
+        ];
+    }
+
     public function testNormalizeFilesSingleUpload(): void
     {
         $files         = [
@@ -229,6 +245,21 @@ final class UploadedFileFactoryTest extends TestCase
     public function testIsValidSapiEnvironmentForUploadsReturnsFalseUnderCli(): void
     {
         // PHPUnit runs under the CLI SAPI, so uploads are not considered valid.
+        // This also covers the real PHP_SAPI lookup in the getSapi() seam.
         self::assertFalse(UploadedFileFactory::isValidSapiEnvironmentForUploads());
+    }
+
+    /**
+     * PHP_SAPI cannot be changed at runtime, so the non-CLI arms are reached
+     * through the getSapi() seam.
+     *
+     * @param non-empty-string $sapi
+     */
+    #[DataProvider('sapiProvider')]
+    public function testIsValidSapiEnvironmentForUploadsBySapi(string $sapi, bool $expected): void
+    {
+        UploadedFileFactorySapiFixture::$sapi = $sapi;
+
+        self::assertSame($expected, UploadedFileFactorySapiFixture::isValidSapiEnvironmentForUploads());
     }
 }


### PR DESCRIPTION
# Description

`UploadedFileFactory::isValidSapiEnvironmentForUploads()` reads `PHP_SAPI` and
returns `! str_starts_with($sapi, 'cli') && ! str_starts_with($sapi, 'phpdbg')`.
Under PHPUnit `PHP_SAPI` is always `cli`, so the first operand is always false
and the second operand is never evaluated — one branch of that condition is
unreachable by any test, and `PHP_SAPI` cannot be changed at runtime.

The remedy is the seam pattern already used for irreducible native calls
elsewhere in the framework (see `ResponseSendRecorderFixture` and the entry
workers): the SAPI lookup moves into a small overridable
`protected static function getSapi()`, called through `static::` so a subclass
can drive it. A `Tests\Fixtures` subclass overrides it to report `cli`,
`cli-server`, `phpdbg`, `apache2handler` and `fpm-fcgi`, which exercises both
operands and both outcomes; the pre-existing real-call test
(`testIsValidSapiEnvironmentForUploadsReturnsFalseUnderCli`) still runs the seam
body itself, so the `PHP_SAPI` read is covered too.

Public behavior is unchanged: `UploadedFileFactory::isValidSapiEnvironmentForUploads()`
still resolves `getSapi()` to the real `PHP_SAPI`.

Verified per-shard (never merged — Xdebug builds a different branch map for a
function depending on whether it ran, so merged shard data invents branches):

```
composer phpunit-path-coverage-shard Http
```

**`src/Valkyrja/Http/Message/File/Factory/UploadedFileFactory.php`: branches
25/26 → 27/27, paths 10/18 → 12/19.** (The denominator grows because the seam
adds a method.)

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Http/Message/File/Factory/UploadedFileFactory.php`** — extracted
  the `PHP_SAPI` read into an overridable `protected static getSapi()` seam and
  called it through `static::` from `isValidSapiEnvironmentForUploads()`.
- **`tests/Tests/Fixtures/Http/Message/File/UploadedFileFactorySapiFixture.php`** —
  new fixture overriding the seam with a settable SAPI name.
- **`tests/Tests/Unit/Http/Message/File/Factory/UploadedFileFactoryTest.php`** —
  added a data-provider test driving the fixture across CLI, CLI server, phpdbg
  and two web SAPIs, and noted that the existing CLI test covers the seam body.
