### PR TITLE
[Cli] Add an overridable exit seam to Exiter

### DIFF
--- a/src/Valkyrja/Cli/Server/Support/Exiter.php
+++ b/src/Valkyrja/Cli/Server/Support/Exiter.php
@@ -38,7 +38,7 @@ class Exiter
      */
     public static function exit(int $code = 0): void
     {
-        static::$exit ? exit($code) : static::frozenCallback($code);
+        static::$exit ? static::exitCallback($code) : static::frozenCallback($code);
     }
 
     /**
@@ -47,5 +47,19 @@ class Exiter
     public static function frozenCallback(int $code = 0): void
     {
         echo $code;
+    }
+
+    /**
+     * Callback for when exiter is not frozen.
+     *
+     * A seam: exit() terminates the process, so no test can call this and go on
+     * to assert anything. A Tests\Fixtures subclass overrides it to record the
+     * call, which is what covers the unfrozen arm of exit().
+     *
+     * @codeCoverageIgnore
+     */
+    protected static function exitCallback(int $code = 0): void
+    {
+        exit($code);
     }
 }

--- a/tests/Tests/Fixtures/Cli/Server/Support/ExiterRecorderFixture.php
+++ b/tests/Tests/Fixtures/Cli/Server/Support/ExiterRecorderFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Fixtures\Cli\Server\Support;
+
+use Override;
+use Valkyrja\Cli\Server\Support\Exiter;
+
+/**
+ * Records the exit seam call made by Exiter when it is not frozen, so tests can
+ * exercise the unfrozen arm without terminating the test process.
+ */
+final class ExiterRecorderFixture extends Exiter
+{
+    /** The code the exit seam was called with, or null if it was not called. */
+    public static int|null $exitedWithCode = null;
+
+    /**
+     * Forget any recorded exit seam call.
+     */
+    public static function reset(): void
+    {
+        self::$exitedWithCode = null;
+    }
+
+    #[Override]
+    protected static function exitCallback(int $code = 0): void
+    {
+        self::$exitedWithCode = $code;
+    }
+}

--- a/tests/Tests/Unit/Cli/Server/Support/ExiterTest.php
+++ b/tests/Tests/Unit/Cli/Server/Support/ExiterTest.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Tests\Unit\Cli\Server\Support;
 
 use Valkyrja\Cli\Interaction\Enum\ExitCode;
 use Valkyrja\Cli\Server\Support\Exiter;
+use Valkyrja\Tests\Fixtures\Cli\Server\Support\ExiterRecorderFixture;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 use function ob_get_clean;
@@ -43,10 +44,45 @@ final class ExiterTest extends TestCase
 
         ob_start();
         Exiter::exit($code);
-        $code = ob_get_clean();
+        $output = ob_get_clean();
 
         Exiter::unfreeze();
 
-        self::assertSame((string) $code, $code);
+        self::assertSame((string) $code, $output);
+    }
+
+    /**
+     * The unfrozen arm calls exit(), which would terminate the test process, so
+     * it is only reachable through a fixture overriding the exit seam.
+     */
+    public function testExitsWhenNotFrozen(): void
+    {
+        $code = ExitCode::AUTO_EXIT->value;
+
+        ExiterRecorderFixture::reset();
+
+        ob_start();
+        ExiterRecorderFixture::exit($code);
+        $output = ob_get_clean();
+
+        self::assertSame($code, ExiterRecorderFixture::$exitedWithCode);
+        self::assertSame('', $output);
+    }
+
+    public function testDoesNotExitWhenFrozen(): void
+    {
+        $code = ExitCode::ERROR->value;
+
+        ExiterRecorderFixture::reset();
+        ExiterRecorderFixture::freeze();
+
+        ob_start();
+        ExiterRecorderFixture::exit($code);
+        $output = ob_get_clean();
+
+        ExiterRecorderFixture::unfreeze();
+
+        self::assertNull(ExiterRecorderFixture::$exitedWithCode);
+        self::assertSame((string) $code, $output);
     }
 }


### PR DESCRIPTION
# Description

`Exiter::exit()` is `static::$exit ? exit($code) : static::frozenCallback($code)`.
Every test has to call `Exiter::freeze()` first, because the unfrozen arm calls
`exit()` and would terminate the PHPUnit process — so that arm was never
executed and its branch could not be covered by any test.

The remedy is the seam pattern already used for irreducible native calls
elsewhere in the framework (the entry workers, `ResponseSendRecorderFixture`):
the bare `exit($code)` moves into its own overridable
`protected static exitCallback()` marked `@codeCoverageIgnore` — that one
statement is genuinely untestable — and `exit()` now dispatches to it through
`static::`. A `Tests\Fixtures` subclass overrides the seam to record the code it
was called with, so the unfrozen arm of the ternary runs under test while the
process survives.

Behavior is unchanged: unfrozen still exits with the given code, frozen still
echoes it via `frozenCallback()`.

While adding the tests I also fixed `ExiterTest::testExitCode`, which reassigned
`$code` from `ob_get_clean()` and then asserted `assertSame((string) $code, $code)`
— comparing the captured output with itself, so it always passed regardless of
what `Exiter` echoed. It now captures the output in `$output` and asserts it
against the exit code.

Verified per-shard (never merged — Xdebug builds a different branch map for a
function depending on whether it ran, so merged shard data invents branches):

```
composer phpunit-path-coverage-shard Cli
```

**`src/Valkyrja/Cli/Server/Support/Exiter.php`: branches 5/6 → 7/7, paths
4/5 → 5/5.** Line coverage stays at 100% — the seam body is excluded via
`@codeCoverageIgnore`.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Cli/Server/Support/Exiter.php`** — moved the bare `exit($code)`
  into an overridable `protected static exitCallback()` seam marked
  `@codeCoverageIgnore`, and dispatched to it from `exit()` via `static::`.
- **`tests/Tests/Fixtures/Cli/Server/Support/ExiterRecorderFixture.php`** — new
  fixture recording the code the exit seam was called with, with a `reset()`
  helper.
- **`tests/Tests/Unit/Cli/Server/Support/ExiterTest.php`** — added tests for the
  unfrozen (seam called, nothing echoed) and frozen (nothing recorded, code
  echoed) arms, and fixed `testExitCode`'s self-comparing assertion.
