### PR TITLE
[Cli] Remove the always-true allowed responses check from QuestionWriter::writeQuestion

### DIFF
--- a/src/Valkyrja/Cli/Interaction/Writer/QuestionWriter.php
+++ b/src/Valkyrja/Cli/Interaction/Writer/QuestionWriter.php
@@ -112,12 +112,12 @@ class QuestionWriter implements WriterContract
 
         $validResponses = $answer->getAllowedResponses();
 
-        if ($validResponses !== []) {
-            // (`valid` or `also valid` or `another valid value`)
-            $output = $output->writeMessage(new Message(' ('));
-            $output = $output->writeMessage(new Message(implode(' or ', array_map(static fn (string $value) => "`$value`", $validResponses))));
-            $output = $output->writeMessage(new Message(')'));
-        }
+        // An answer always carries at least its default response, so there is always at least one
+        // valid response to render.
+        // (`valid` or `also valid` or `another valid value`)
+        $output = $output->writeMessage(new Message(' ('));
+        $output = $output->writeMessage(new Message(implode(' or ', array_map(static fn (string $value) => "`$value`", $validResponses))));
+        $output = $output->writeMessage(new Message(')'));
 
         // [default: "defaultResponse"]
         $output = $output->writeMessage(new Message(' [default: "'));


### PR DESCRIPTION
# Description

`QuestionWriter::writeQuestion()` guarded the allowed-response list with a condition that can never
be `false`:

```php
$validResponses = $answer->getAllowedResponses();

if ($validResponses !== []) {
    // (`valid` or `also valid` or `another valid value`)
    ...
}
```

An `Answer` always carries at least its default response — the constructor appends it when absent,
and `withAllowedResponses()` and `withDefaultResponse()` both re-add it — so `getAllowedResponses()`
never returns an empty array and the guard is always taken. This is the same invariant that made the
first clause of `Answer::isValidResponse()` dead code in #945; this is the other place that assumed
otherwise.

Unlike #945, this was **not** visible as a branch-coverage gap, which is worth recording. Xdebug
counts basic blocks *hit*, not edges *taken*: because the condition is always true, control flows
entry to if-body to after-if, so all three blocks execute and `writeQuestion` reported 100% branch
coverage. The unreachable edge showed up only in **path** coverage, which is report-only and gated
by nothing. Measured per function on the `Cli` shard:

| `writeQuestion` | branches | paths |
|-----------------|----------|-------|
| before          | 3/3      | 1/2   |
| after           | 1/1      | 1/1   |

Behavior is unchanged: the guard was always taken, so the same messages are written in the same
order. The Java port already does exactly this and documents the invariant in place; the comment
added here is worded to match `QuestionWriter.java`, so the ports read alike. The TypeScript port
still has both this and the `Answer` issue, tracked separately.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Cli/Interaction/Writer/QuestionWriter.php`** — removed the always-true
  `$validResponses !== []` guard from `writeQuestion()` and documented the invariant that an answer
  always carries at least its default response, matching the Java port's wording. Closes the
  function's one unreachable execution path with no change in behavior.



## Sibling PRs

- TypeScript (same two fixes) — valkyrjaio/valkyrja-ts#99
- PHP `Answer::isValidResponse()` — #945 (merged)
- Java — already correct, no change needed
