### PR TITLE
[Type] Move the enum json serialization branch out of the trait

### DIFF
--- a/src/Valkyrja/Type/Enum/Support/Enumerable.php
+++ b/src/Valkyrja/Type/Enum/Support/Enumerable.php
@@ -110,6 +110,20 @@ class Enumerable
     }
 
     /**
+     * Get the json serializable representation of an enum case.
+     *
+     * @param UnitEnum $enum The enum case
+     */
+    public static function jsonSerialize(UnitEnum $enum): string|int
+    {
+        if ($enum instanceof BackedEnum) {
+            return $enum->value;
+        }
+
+        return $enum->name;
+    }
+
+    /**
      * Determine whether a name is valid for a given enum.
      *
      * @param class-string<UnitEnum> $enum The enum class name

--- a/src/Valkyrja/Type/Enum/Trait/JsonSerializable.php
+++ b/src/Valkyrja/Type/Enum/Trait/JsonSerializable.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Type\Enum\Trait;
 
-use BackedEnum;
+use Valkyrja\Type\Enum\Support\Enumerable;
 
 trait JsonSerializable
 {
@@ -22,10 +22,6 @@ trait JsonSerializable
      */
     public function jsonSerialize(): string|int
     {
-        if ($this instanceof BackedEnum) {
-            return $this->value;
-        }
-
-        return $this->name;
+        return Enumerable::jsonSerialize($this);
     }
 }

--- a/tests/Tests/Unit/Type/Enum/Support/EnumTest.php
+++ b/tests/Tests/Unit/Type/Enum/Support/EnumTest.php
@@ -116,4 +116,11 @@ final class EnumTest extends TestCase
         self::assertTrue(Enumerable::isValidValue(ArrayableIntEnum::class, 2));
         self::assertFalse(Enumerable::isValidValue(ArrayableIntEnum::class, 3));
     }
+
+    public function testJsonSerialize(): void
+    {
+        self::assertSame('heart', Enumerable::jsonSerialize(ArrayableEnum::heart));
+        self::assertSame('bar', Enumerable::jsonSerialize(ArrayableStringEnum::foo));
+        self::assertSame(1, Enumerable::jsonSerialize(ArrayableIntEnum::first));
+    }
 }


### PR DESCRIPTION
# Description

`Type\Enum\Trait\JsonSerializable::jsonSerialize()` branched on
`$this instanceof BackedEnum` inside the trait itself, and that branch could not
be covered reliably — not because a test was missing, but because of how Xdebug
reports trait methods.

Xdebug emits exactly **one** function entry per file for a trait method, keyed by
the trait rather than by the using class:

```
Type/Enum/Trait/JsonSerializable.php
  function: Valkyrja\Type\Enum\Trait\JsonSerializable->jsonSerialize
```

Every using class shares that entry, so which class's copy the hits reflect
depends on class load order. A backed enum never runs `return $this->name` and a
pure enum never runs `return $this->value`, so the file's reported coverage
depends on which kind of enum happened to be loaded — and **adding tests made it
worse**:

| Run | `if` | `return $this->value` | `return $this->name` | Result |
|-----|------|-----------------------|----------------------|--------|
| `--filter JsonSerializableTest` | hit | hit | hit | 3/3 |
| `--filter 'JsonSerializableTest\|ArrayableTest'` | hit | hit | miss | 2/3 |
| full `Type` shard | hit | hit | miss | 2/3 |

`ArrayableTest` never calls `jsonSerialize()`; it only loads the same enum
fixtures first. That alone flips the pure-enum arm to unhit, so no test can close
this gap. (php-code-coverage's own merging is a strict union —
`ProcessedBranchCoverageData::merge` and `markCodeAsExecutedByTestCase` — so the
loss happens in Xdebug's raw per-test data, upstream of any merge.)

The fix keeps the branch but moves it out of the trait, following the pattern
this namespace already uses: `Trait\Arrayable` holds no logic and delegates to
`Support\Enumerable`. `Trait\JsonSerializable` now does the same, and the
conditional lives in `Support\Enumerable::jsonSerialize()` — an ordinary class,
where coverage is per-class and stable.

Public API is unchanged: `use JsonSerializable;` still works, the
`JsonSerializableContract` is untouched, and the serialized output is identical
(value for backed enums, name for pure enums).

Verified per-shard (never merged — Xdebug builds a different branch map for a
function depending on whether it ran, so merged shard data invents branches):

```
composer phpunit-path-coverage-shard Type
```

- **`src/Valkyrja/Type/Enum/Trait/JsonSerializable.php`: branches 2/3 → 1/1,
  paths 1/2 → 1/1.**
- **`src/Valkyrja/Type/Enum/Support/Enumerable.php`: branches 12/12 → 15/15,
  paths 9/9 → 11/11** — the moved branch is fully covered in its new home.

The Type shard's `GAPS=1` list drops from 4 files to 3; the remaining three are
owned by other shards.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Type/Enum/Support/Enumerable.php`** — added
  `jsonSerialize(UnitEnum $enum): string|int`, holding the backed-vs-pure enum
  branch.
- **`src/Valkyrja/Type/Enum/Trait/JsonSerializable.php`** — the trait method now
  just delegates to `Enumerable::jsonSerialize($this)`, mirroring how
  `Trait\Arrayable` delegates to the same support class.
- **`tests/Tests/Unit/Type/Enum/Support/EnumTest.php`** — added a direct test of
  `Enumerable::jsonSerialize()` for a pure, a string-backed and an int-backed
  enum.
