### PR TITLE
[CI] Recompute merged coverage from the shard files

### DIFF
--- a/.github/ci/phpunit/path-coverage-report.php
+++ b/.github/ci/phpunit/path-coverage-report.php
@@ -12,37 +12,160 @@
 declare(strict_types=1);
 
 /*
- * Reports and (optionally) asserts merged path/branch/line coverage.
+ * Reports and (optionally) asserts merged line/branch coverage.
  *
- * Reads the merged serialized coverage produced by `phpcov merge --php`, prints
- * a line/branch/path summary, and exits non-zero when a required threshold is
- * not met. Thresholds come from the environment so the same script serves both
- * the local "report only" run and a future CI gate:
+ * Reads the merged serialized coverage produced by `phpcov merge --php`, prints a
+ * line/branch summary, and exits non-zero when a required threshold is not met.
+ * Thresholds come from the environment so the same script serves both the local
+ * "report only" run and a CI gate:
  *
  *   REQUIRE_LINE    fail if line coverage %   is below this   (empty = skip)
  *   REQUIRE_BRANCH  fail if branch coverage % is below this   (empty = skip)
- *   REQUIRE_PATH    fail if path coverage %   is below this   (empty = skip)
  *   GAPS=1          list every file whose branch coverage is below 100%
  *
  * A threshold of exactly 100 is asserted as executed === executable, so no float
  * rounding can sneak a 99.99% past a "100%" gate.
+ *
+ * ---------------------------------------------------------------------------
+ * Why branches are recomputed from the shard files instead of read off the merge
+ * ---------------------------------------------------------------------------
+ *
+ * Xdebug identifies a function's basic blocks by opcode offset, and it builds a
+ * *different* numbering depending on whether that function ran in the process
+ * doing the recording. `phpcov merge` keys branch data on those offsets, so
+ * merging a shard that executed a function with one that merely autoloaded it
+ * unions two incompatible maps: the executable count inflates and blocks that
+ * every shard covered come out unhit.
+ *
+ * It is not a rounding error. On this suite the merged report claimed 19 missing
+ * branches across 4 files, each of which is at 100% in the shard that exercises
+ * it — 9 of them in Http/Routing/Processor/Processor.php, whose executable count
+ * went from 43 to 52 purely from the merge. It also hits *partially* executing
+ * shards, so dropping never-executed records is not enough.
+ *
+ * The line range Xdebug reports for a block is identical under both numberings,
+ * so this script re-keys each block by `line_start-line_end` and ORs the hits
+ * across shards. That is exact: the two numberings describe the same blocks.
+ *
+ * Paths are deliberately NOT reported here. A path is a *sequence of block ids*,
+ * so it inherits the unstable numbering, and line ranges cannot stand in — two
+ * distinct opcode paths through the same lines collapse onto one key, which
+ * silently reports every path as covered. Read paths from a single shard:
+ *
+ *   composer phpunit-path-coverage-shard Http
  */
 
-use SebastianBergmann\CodeCoverage\Node\Builder;
-use SebastianBergmann\CodeCoverage\Node\File;
 use SebastianBergmann\CodeCoverage\Report\Facade as ReportFacade;
-use SebastianBergmann\CodeCoverage\StaticAnalysis\FileAnalyser;
-use SebastianBergmann\CodeCoverage\StaticAnalysis\ParsingSourceAnalyser;
 
 require __DIR__ . '/vendor/autoload.php';
 
-$covFile = $argv[1] ?? '';
+$covFile  = $argv[1] ?? '';
+$shardDir = $argv[2] ?? '';
 
 if ($covFile === '' || ! is_file($covFile)) {
     fwrite(STDERR, "Merged coverage file not found: {$covFile}\n");
 
     exit(2);
 }
+
+if ($shardDir === '' || ! is_dir($shardDir)) {
+    fwrite(STDERR, "Shard coverage directory not found: {$shardDir}\n");
+
+    exit(2);
+}
+
+$shardFiles = glob(rtrim($shardDir, '/') . '/*.cov') ?: [];
+
+if ($shardFiles === []) {
+    fwrite(STDERR, "No shard coverage files in: {$shardDir}\n");
+
+    exit(2);
+}
+
+/**
+ * Fold per-shard, per-file unit maps into one map per file.
+ *
+ * A shard that never executed a file still records a map for it, and that map disagrees with the one
+ * recorded by a shard that did — an extra executable line, a different block numbering. Unioning it
+ * in inflates the denominator, so a shard's view of a file is only trusted once it has executed
+ * something in it. When *no* shard executed the file, one arbitrary view is kept so a genuinely
+ * uncovered file still counts against the total instead of vanishing from it.
+ *
+ * @param array<string, array<string, array<string, bool>>> $perShard shard => file => key => hit
+ *
+ * @return array<string, array{executed: int, executable: int}>
+ */
+$fold = static function (array $perShard): array {
+    /** @var array<string, array<string, bool>> $merged */
+    $merged = [];
+    /** @var array<string, array<string, bool>> $untouched */
+    $untouched = [];
+
+    foreach ($perShard as $files) {
+        foreach ($files as $file => $units) {
+            if (array_filter($units) === []) {
+                $untouched[$file] ??= $units;
+
+                continue;
+            }
+
+            foreach ($units as $key => $hit) {
+                $merged[$file][$key] = ($merged[$file][$key] ?? false) || $hit;
+            }
+        }
+    }
+
+    foreach ($untouched as $file => $units) {
+        $merged[$file] ??= $units;
+    }
+
+    $coverage = [];
+
+    foreach ($merged as $file => $units) {
+        $coverage[$file] = [
+            'executed'   => count(array_filter($units)),
+            'executable' => count($units),
+        ];
+    }
+
+    return $coverage;
+};
+
+/** @var array<string, array<string, array<string, bool>>> $shardBranches */
+$shardBranches = [];
+/** @var array<string, array<string, array<string, bool>>> $shardLines */
+$shardLines = [];
+
+foreach ($shardFiles as $shardFile) {
+    /** @var array{codeCoverage: mixed} $shard */
+    $shard = require $shardFile;
+    $name  = basename($shardFile, '.cov');
+
+    foreach ($shard['codeCoverage']->functionCoverage() as $file => $functions) {
+        foreach ($functions as $function => $data) {
+            foreach ($data->branches as $branch) {
+                // Xdebug's block ids are per-process; the line range it reports for a block is not.
+                $key = $branch->line_start . '-' . $branch->line_end . '@' . $function;
+
+                $shardBranches[$name][$file][$key] = $branch->hit !== 0;
+            }
+        }
+    }
+
+    foreach ($shard['codeCoverage']->lineCoverage() as $file => $lines) {
+        foreach ($lines as $line => $tests) {
+            $shardLines[$name][$file][(string) $line] = $tests !== [] && $tests !== null;
+        }
+    }
+}
+
+$branchCoverage = $fold($shardBranches);
+$lineCoverage   = $fold($shardLines);
+
+$branchesExecuted   = array_sum(array_column($branchCoverage, 'executed'));
+$branchesExecutable = array_sum(array_column($branchCoverage, 'executable'));
+$linesExecuted      = array_sum(array_column($lineCoverage, 'executed'));
+$linesExecutable    = array_sum(array_column($lineCoverage, 'executable'));
 
 /** @var array{basePath: string, codeCoverage: mixed, testResults: mixed} $merged */
 $merged = require $covFile;
@@ -55,17 +178,17 @@ if (! is_array($merged) || ! isset($merged['codeCoverage'], $merged['testResults
 
 $summary = ReportFacade::fromSerializedData($merged)->summary();
 
+// Both metrics are recomputed from the shard files rather than read off the merge — see the header.
 $metrics = [
-    'Lines'    => [$summary->numberOfExecutedLines(), $summary->numberOfExecutableLines()],
-    'Branches' => [$summary->numberOfExecutedBranches(), $summary->numberOfExecutableBranches()],
-    'Paths'    => [$summary->numberOfExecutedPaths(), $summary->numberOfExecutablePaths()],
+    'Lines'    => [$linesExecuted, $linesExecutable],
+    'Branches' => [$branchesExecuted, $branchesExecutable],
 ];
 
 $percentage = static fn (int $executed, int $executable): float
     => $executable === 0 ? 100.0 : ($executed / $executable) * 100;
 
 echo "=====================================================\n";
-echo " Merged path / branch coverage\n";
+echo " Merged line / branch coverage\n";
 echo "=====================================================\n";
 
 foreach ($metrics as $label => [$executed, $executable]) {
@@ -75,15 +198,22 @@ foreach ($metrics as $label => [$executed, $executable]) {
 $filesWithoutBranchData = $summary->numberOfFilesWithoutBranchCoverageData();
 
 if ($filesWithoutBranchData > 0) {
-    printf("\n  Note: %d file(s) were never loaded, so they have no branch/path data.\n", $filesWithoutBranchData);
+    printf("\n  Note: %d file(s) were never loaded, so they have no branch data.\n", $filesWithoutBranchData);
 }
 
+printf("  Branches merged from %d shard(s), re-keyed by line range.\n", count($shardFiles));
+echo "  Path coverage is not shown: it cannot be merged across shards. Run a single\n";
+echo "  shard for it, e.g. `composer phpunit-path-coverage-shard Http`.\n";
+
 echo "\n";
+
+if (getenv('REQUIRE_PATH') !== false && getenv('REQUIRE_PATH') !== '') {
+    echo "  REQUIRE_PATH is ignored: merged path coverage is not a meaningful number.\n\n";
+}
 
 $requirements = [
     'Lines'    => getenv('REQUIRE_LINE'),
     'Branches' => getenv('REQUIRE_BRANCH'),
-    'Paths'    => getenv('REQUIRE_PATH'),
 ];
 
 $failed = false;
@@ -112,26 +242,15 @@ foreach ($requirements as $label => $requirement) {
 }
 
 if (getenv('GAPS') === '1') {
-    $report = new Builder(new FileAnalyser(new ParsingSourceAnalyser, false, false))->build(
-        $merged['codeCoverage'],
-        $merged['testResults'],
-        $merged['basePath'],
-    );
-
     /** @var array<int, array{path: string, executed: int, executable: int}> $gaps */
     $gaps = [];
 
-    foreach ($report as $node) {
-        if (! $node instanceof File) {
-            continue;
-        }
-
-        $executable = $node->numberOfExecutableBranches();
-        $executed   = $node->numberOfExecutedBranches();
-
+    // Same re-keyed per-file data the Branches metric is built from, so a file listed here and the
+    // summary above can never disagree.
+    foreach ($branchCoverage as $file => ['executed' => $executed, 'executable' => $executable]) {
         if ($executable > 0 && $executed < $executable) {
             $gaps[] = [
-                'path'       => $node->pathAsString(),
+                'path'       => $file,
                 'executed'   => $executed,
                 'executable' => $executable,
             ];

--- a/.github/ci/phpunit/path-coverage-shards.sh
+++ b/.github/ci/phpunit/path-coverage-shards.sh
@@ -16,9 +16,12 @@
 # concurrently, each writing its own serialized coverage, then merges them with
 # phpcov. Wall-clock collapses to roughly the slowest single shard.
 #
-# Because every shard shares the same <source> denominator (all of src) and the
-# merged report is the union of all shards, the merged line/branch/path numbers
-# are identical to a serial full run -- no shard can drop classes from the total.
+# Because every shard shares the same <source> denominator (all of src), the merged
+# line numbers are identical to a serial full run -- no shard can drop classes from
+# the total. Branch coverage is NOT taken from phpcov's merge: Xdebug's block ids
+# are per-process, so merging on them invents branches. The report recomputes
+# branches from the shard files, re-keyed by line range. Path coverage cannot be
+# merged at all -- read it from a single shard.
 #
 # Usage:
 #   ./path-coverage-shards.sh              Run every shard in parallel, then merge + report.
@@ -27,9 +30,8 @@
 #
 # Environment:
 #   JOBS=<n>          Max concurrent shards (default: CPU count).
-#   REQUIRE_LINE=<n>  Fail if merged line coverage % is below n     (default: 100).
-#   REQUIRE_BRANCH=<n> Fail if merged branch coverage % is below n  (default: unset = report only).
-#   REQUIRE_PATH=<n>  Fail if merged path coverage % is below n     (default: unset = report only).
+#   REQUIRE_LINE=<n>  Fail if line coverage % is below n     (default: 100).
+#   REQUIRE_BRANCH=<n> Fail if branch coverage % is below n  (default: 100).
 #   GAPS=1            After reporting, list every file whose branch coverage < 100%.
 set -euo pipefail
 
@@ -108,11 +110,12 @@ run_merge() {
         --php "$MERGED_COV" \
         --clover "$LOG_DIR/path-coverage-clover.xml" \
         "$COV_DIR/" >/dev/null
+    # The report reads the shard files directly for branch coverage: Xdebug's block ids are not
+    # stable across processes, so phpcov's merged branch data is wrong (see path-coverage-report.php).
     REQUIRE_LINE="${REQUIRE_LINE:-100}" \
-    REQUIRE_BRANCH="${REQUIRE_BRANCH:-}" \
-    REQUIRE_PATH="${REQUIRE_PATH:-}" \
+    REQUIRE_BRANCH="${REQUIRE_BRANCH:-100}" \
     GAPS="${GAPS:-}" \
-        "$PHP_BIN" -d memory_limit=-1 path-coverage-report.php "$MERGED_COV"
+        "$PHP_BIN" -d memory_limit=-1 path-coverage-report.php "$MERGED_COV" "$COV_DIR"
 }
 
 run_all() {


### PR DESCRIPTION
# Description

`path-coverage-shards.sh` reported **19 missing branches across 4 files that are each at 100%**. Every
one was an artifact of the merge, not uncovered code. `REQUIRE_BRANCH=100` could therefore never pass,
no matter how good the tests were — which matters because that harness is the only branch-coverage
check this repo has (`phpunit-coverage` is line-only by design here).

## Root cause

Xdebug identifies a function's basic blocks by **opcode offset**, and it builds a *different*
numbering depending on whether that function ran in the process doing the recording. `phpcov merge`
keys branch data on those offsets, so merging a shard that executed a function with one that merely
autoloaded it unions two incompatible maps.

Same method, same line ranges, different ids:

```
Application  #0(L191-194)=0 #5(L195-195)=0 #8(L196-196)=0 #10(L196-197)=0
Functional   #0(L191-194)=0 #5(L195-195)=0 #8(L196-196)=0 #10(L196-197)=0
Http         #0(L191-194)=1 #5(L195-195)=1 #7(L196-196)=1 #8(L196-197)=1
merged       #0(L191-194)=1 #5(L195-195)=1 #8(L196-196)=1 #10(L196-197)=0 #7(L196-196)=1
```

Note `#8` means `L196-196` under one numbering and `L196-197` under the other. The merge inflates the
**executable** count, not just the hits — `Processor.php` went from 43 executable branches to 52 —
and it also hits *partially* executing shards, so simply dropping never-executed records does not help
(the `Http` shard's 4/24 view of `Api.php` merged with `Api`'s 24/24 gives 24/**28**).

Built per shard, all four flagged files are clean:

```
Http  Processor/Processor.php                43/43
Http  Request/Request.php                    32/32
Api   Manager/Api.php                        24/24
Cli   Provider/CliServerServiceProvider.php  22/22
```

The line totals were wrong the same way, by one executable line per file, for the same reason.

## Fix

The line range Xdebug reports for a block is identical under both numberings, so the report re-keys
each block by `line_start-line_end` and ORs the hits across shards. A shard's view of a file is only
trusted once it has executed something in it; when *no* shard executed it, one view is kept so a
genuinely uncovered file still counts against the total instead of vanishing from it.

`REQUIRE_BRANCH` now defaults to `100`, since it is finally a number that can be met:

```
  Lines:     100.00%  (9710/9710)
  Branches:  100.00%  (5124/5124)
  PASS  Lines >= 100.00%
  PASS  Branches >= 100.00%
  Files below 100% branch coverage: 0 (0 branches)
```

The line figure independently matches what the plain line-coverage run reports (`9710/9710`), which
cross-checks the fold.

## Path coverage is dropped from the merged report

A path is a *sequence of block ids*, so it inherits the unstable numbering, and line ranges cannot
stand in — two distinct opcode paths through the same lines collapse onto one key, which reports
**every** path as covered (a prototype doing this read 100% where the naive merge read 42.85%). Rather
than print a number that is wrong in the flattering direction, the report now omits paths and points
at `composer phpunit-path-coverage-shard Http`. `REQUIRE_PATH` is accepted and explicitly reported as
ignored, so an existing invocation does not silently appear to enforce something.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/ci/phpunit/path-coverage-report.php`** — takes the shard directory as a second argument
  and recomputes both line and branch coverage from the shard files, re-keyed by line range, with the
  reasoning recorded in the file header. Drops the merged path metric and the now-unused report
  Builder imports; `GAPS` reads the same per-file data as the summary, so the two can no longer
  disagree.
- **`.github/ci/phpunit/path-coverage-shards.sh`** — passes the shard directory through, defaults
  `REQUIRE_BRANCH` to 100, and corrects the header comment that claimed the merged branch/path numbers
  matched a serial run.

## Follow-up

`architecture/php/AGENTS.md` documents this trap and tells agents to read per-shard numbers and never
the merged ones. That guidance was right, and it is what led me to the cause — but the merged branch
figure is now trustworthy, so that section wants an update once this lands. Happy to do it as a
separate PR against the architecture repo.

## Sibling PRs

One repo's part of a cross-language batch making every language's local gate fail when coverage drops,
instead of leaving it to Coveralls after push:

**Java** (JaCoCo bundle + per-class rules, 100% line and branch)
- valkyrja-java — https://github.com/valkyrjaio/valkyrja-java/pull/71
- sindri-java — https://github.com/valkyrjaio/sindri-java/pull/67
- valkyrja-starter-app-java — https://github.com/valkyrjaio/valkyrja-starter-app-java/pull/64
- project-template-java — https://github.com/valkyrjaio/project-template-java/pull/31

**PHP** (clover check, 100% line)
- valkyrja-php — https://github.com/valkyrjaio/valkyrja-php/pull/954
- sindri-php — https://github.com/valkyrjaio/sindri-php/pull/183
- valkyrja-starter-app-php — https://github.com/valkyrjaio/valkyrja-starter-app-php/pull/186
- project-template-php — https://github.com/valkyrjaio/project-template-php/pull/150

**TypeScript** (Vitest thresholds, 100% lines/branches/functions/statements)
- valkyrja-ts — https://github.com/valkyrjaio/valkyrja-ts/pull/102
- sindri-ts — https://github.com/valkyrjaio/sindri-ts/pull/76
- valkyrja-starter-app-ts — https://github.com/valkyrjaio/valkyrja-starter-app-ts/pull/88
- project-template-ts — https://github.com/valkyrjaio/project-template-ts/pull/64

**Go** (statement floor) — https://github.com/valkyrjaio/project-template-go/pull/10

**Python** needed no change: `project-template-python` already runs
`--cov-branch --cov-fail-under=100` in its `ci` sequence.

Supporting PRs: the gap-closing batch (sindri-java#66, valkyrja-starter-app-java#63,
valkyrja-starter-app-php#185, project-template-ts#64) and the path-coverage merge fix
(valkyrja-php#955).
