### PR TITLE
[Workflow] ci: Rerun checks when a pull request is edited or retargeted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [ 'master', '*.x' ]
   pull_request:
+    # `edited` is included so a pull request that GitHub auto-retargets — which happens to a stacked
+    # pull request the moment its parent merges — re-runs its checks. A base-branch change has no
+    # activity type of its own; GitHub reports it as `edited` with a `changes.base` payload, and
+    # `edited` is not one of the default types, so such a pull request otherwise sits with no checks
+    # at all. `edited` also fires for title and description edits, so the tool jobs below additionally
+    # require `changes.base` rather than replaying a whole matrix for a reworded description.
+    types: [ opened, synchronize, reopened, edited ]
     branches: [ 'master', '*.x' ]
 
 permissions:
@@ -28,6 +35,7 @@ jobs:
 
   phparkitect:
     name: PHPArkitect
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phparkitect-php/.github/workflows/_workflow-call.yml@2ec6d1cb187ce2242270c0a3f4572b76de3b8db3
     with:
       php-version: '8.4'
@@ -47,6 +55,7 @@ jobs:
 
   phpcodesniffer:
     name: PHP Code Sniffer
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpcodesniffer-php/.github/workflows/_workflow-call.yml@71d50ad10a9cc2e9ef6b15f1d299bddff72b0027
     with:
       php-version: '8.4'
@@ -66,6 +75,7 @@ jobs:
 
   phpcsfixer:
     name: PHP CS Fixer
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpcsfixer-php/.github/workflows/_workflow-call.yml@c787357a29476f7264e5c8a64057bf9d5c1f86f7
     with:
       php-version: '8.4'
@@ -85,6 +95,7 @@ jobs:
 
   phpstan:
     name: PHPStan
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpstan-php/.github/workflows/_workflow-call.yml@766dcf38e0d178e198c5dcbb1ec6bc55f4732599
     with:
       php-version: '8.4'
@@ -109,6 +120,7 @@ jobs:
 
   phpunit:
     name: PHPUnit
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpunit-php/.github/workflows/_workflow-call.yml@ca27f8c28932012e8ec6e25c9c949bc410e68b02
     with:
       php-versions: '["8.4", "8.5", "8.6"]'
@@ -134,6 +146,7 @@ jobs:
 
   psalm:
     name: Psalm
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-psalm-php/.github/workflows/_workflow-call.yml@1f216925b5ff78a88c1728d734cab165071b11c2
     with:
       php-version: '8.4'
@@ -159,6 +172,7 @@ jobs:
 
   rector:
     name: Rector
+    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-rector-php/.github/workflows/_workflow-call.yml@c104cba4c458c87eb63e1e70307eba81cb9532ca
     with:
       php-version: '8.4'


### PR DESCRIPTION
# Description

Applies the CI trigger change from
[valkyrjaio/.github#170](https://github.com/valkyrjaio/.github/pull/170) to this repository.

When a stacked pull request's parent merges, GitHub auto-retargets the child's base branch — and the
child then sits with **no checks at all**. It happened twice recently, on `sindri-java#67` and
`valkyrja-starter-app-java#64`: both retargeted to `26.x` and showed only the third-party SonarCloud
status, because nothing in CI had run. Each needed a manual force-push to come unstuck.

The cause is an activity-type gap. `pull_request` has no activity type for a base-branch change;
GitHub reports it as `edited`, with the previous base in a `changes.base` payload. `ci.yml` declares
`pull_request` with no `types:`, so it gets the defaults — `opened`, `synchronize`, `reopened` — and
`edited` is not among them, so nothing CI listens for ever fires.

#170 fixed the canonical templates in `required-workflows/`, but that does not reach any existing
repository: `_ensure-workflows.yml` merges CI **jobs** — it appends job blocks a repo is missing and
exits without changes when none are missing — and never touches the `on:` block. So the same edit has
to be made in each repo's own `ci.yml`. This is that edit.

## The change

`edited` is added to the trigger, and the jobs are split by what should react to it:

- **`commit-message-check` and `trailing-newline-check` run on every edit.** They already carry
  `if: github.event_name == 'pull_request'` and are left untouched, so they now also fire on `edited`.
  That is wanted: the commit-message check validates the **pull request title**, which is exactly what
  an edit changes, so a title corrected to satisfy the convention re-verifies immediately instead of
  waiting for an unrelated push.
- **Every tool job additionally requires a base change.** `edited` is a single activity type covering
  base, title *and* description changes, so without a guard every reworded description would replay
  the whole matrix. Each tool job gets:

  ```yaml
  if: github.event.action != 'edited' || github.event.changes.base
  ```

  On a `push` there is no `action`, so the first clause is true and the job runs exactly as before.
  Same for `opened` / `synchronize` / `reopened`. On `edited` it runs only when the base actually moved.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/workflows/ci.yml`** — adds `types: [ opened, synchronize, reopened, edited ]` and the base-change guard to 7 tool job(s).

Additions only; the file still parses as valid YAML and no job was added, removed or otherwise altered.
