### PR TITLE
[Workflow] ci: Run the full suite on pull request edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,16 @@ on:
     branches: [ 'master', '*.x' ]
   pull_request:
     # `edited` is included so a pull request that GitHub auto-retargets — which happens to a stacked
-    # pull request the moment its parent merges — re-runs its checks. A base-branch change has no
-    # activity type of its own; GitHub reports it as `edited` with a `changes.base` payload, and
-    # `edited` is not one of the default types, so such a pull request otherwise sits with no checks
-    # at all. `edited` also fires for title and description edits, so the tool jobs below additionally
-    # require `changes.base` rather than replaying a whole matrix for a reworded description.
+    # pull request the moment its parent merges — re-runs its checks against the new base. A
+    # base-branch change has no activity type of its own; GitHub reports it as `edited`, and `edited`
+    # is not one of the default types, so such a pull request otherwise sits with no checks at all.
+    #
+    # `edited` also fires for title and description edits, so the whole suite re-runs for those too.
+    # That cost is accepted deliberately. Skipping the jobs instead — via a `changes.base` guard —
+    # does not work: a skipped caller job never produces the `<job> / <job>` context the required
+    # status checks are waiting for, and GitHub evaluates requirements against the latest run, so an
+    # earlier run's success does not carry over. The pull request ends up blocked on
+    # "Expected — Waiting for status to be reported" until someone pushes a commit.
     types: [ opened, synchronize, reopened, edited ]
     branches: [ 'master', '*.x' ]
 
@@ -35,7 +40,6 @@ jobs:
 
   phparkitect:
     name: PHPArkitect
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phparkitect-php/.github/workflows/_workflow-call.yml@2ec6d1cb187ce2242270c0a3f4572b76de3b8db3
     with:
       php-version: '8.4'
@@ -55,7 +59,6 @@ jobs:
 
   phpcodesniffer:
     name: PHP Code Sniffer
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpcodesniffer-php/.github/workflows/_workflow-call.yml@71d50ad10a9cc2e9ef6b15f1d299bddff72b0027
     with:
       php-version: '8.4'
@@ -75,7 +78,6 @@ jobs:
 
   phpcsfixer:
     name: PHP CS Fixer
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpcsfixer-php/.github/workflows/_workflow-call.yml@c787357a29476f7264e5c8a64057bf9d5c1f86f7
     with:
       php-version: '8.4'
@@ -95,7 +97,6 @@ jobs:
 
   phpstan:
     name: PHPStan
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpstan-php/.github/workflows/_workflow-call.yml@766dcf38e0d178e198c5dcbb1ec6bc55f4732599
     with:
       php-version: '8.4'
@@ -120,7 +121,6 @@ jobs:
 
   phpunit:
     name: PHPUnit
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-phpunit-php/.github/workflows/_workflow-call.yml@ca27f8c28932012e8ec6e25c9c949bc410e68b02
     with:
       php-versions: '["8.4", "8.5", "8.6"]'
@@ -146,7 +146,6 @@ jobs:
 
   psalm:
     name: Psalm
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-psalm-php/.github/workflows/_workflow-call.yml@1f216925b5ff78a88c1728d734cab165071b11c2
     with:
       php-version: '8.4'
@@ -172,7 +171,6 @@ jobs:
 
   rector:
     name: Rector
-    if: github.event.action != 'edited' || github.event.changes.base
     uses: valkyrjaio/ci-rector-php/.github/workflows/_workflow-call.yml@c104cba4c458c87eb63e1e70307eba81cb9532ca
     with:
       php-version: '8.4'


### PR DESCRIPTION
# Description

Removes the `changes.base` guard added in the previous CI trigger change, keeping the `edited`
activity type. Every pull request edit now re-runs the full suite.

## Why the guard had to go

The guard was `if: github.event.action != 'edited' || github.event.changes.base` on each tool job, so
a title or description edit would skip them instead of replaying the matrix. It does not work, and it
breaks merging.

When a caller job that `uses:` a reusable workflow is skipped, the reusable workflow never runs, so
the `<job> / <job>` context the required status checks are waiting for is **never produced**. GitHub
evaluates requirements against the **latest run** of the workflow, so an earlier run's success does
not carry over — it stays visible in the check-runs API but stops counting. Confirmed on a live pull
request: after a description edit, three runs existed on one unchanged head SHA and the pull request
showed

```
golangci-lint / golangci-lint   Expected — Waiting for status to be reported   Required
Test / Test                     Expected — Waiting for status to be reported   Required
golangci-lint                   Skipped
Test                            Skipped
```

Note the names: the skip reports the bare caller name (`Test`), not the required context
(`Test / Test`). So the requirement is simply absent, and the pull request is blocked until someone
pushes a commit.

## Why `edited` stays

A retargeted pull request must be re-verified, not just unblocked. Checks that passed against the old
base parent say nothing about `26.x` or `master` — the merge result is different. Re-running the suite
against the new base is the point of reacting to the retarget at all.

The cost is that a reworded title or description also re-runs everything. That is accepted
deliberately; the reasoning is recorded in a comment in the trigger block so the guard is not
reintroduced later.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/workflows/ci.yml`** — removes the base-change guard from 7 tool job(s); the `types:` list is unchanged.
