### PR TITLE
[Workflow] ci: Update the release bump input to the conventional options

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -4,13 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Version component to bump'
+        description: 'Version component to bump (auto, patch, feature, yearly, or rc)'
         required: true
         type: choice
+        default: auto
         options:
+          - auto
           - patch
-          - minor
-          - major
+          - feature
+          - yearly
           - rc
 
 run-name: "Release ${{ inputs.bump }} bump on ${{ github.ref_name }}"


### PR DESCRIPTION
# Description

Updates this repo's release dispatcher to the conventional bump options adopted org-wide
in [valkyrjaio/.github#173](https://github.com/valkyrjaio/.github/pull/173).

`major` and `minor` were misleading names. `major` never incremented anything — on a
`YY.x` branch it always produced `YY.0.0`, so it only ever meant "the first release on
this year's branch", which is now `yearly`. `minor` was the component that actually moved
for both features and breaking changes, which is now `feature`.

The new default, `auto`, resolves the bump from the conventional commit types merged since
the last tag: any `feat`, `deprecate`, or `!` gives a feature bump, anything else a patch,
and nothing pending means no release at all. See
[VERSIONING.md](https://github.com/valkyrjaio/architecture/blob/master/VERSIONING.md).

This is required before the scheduled auto-release sweep can run — it dispatches
`bump=auto`, which the old dropdown rejects as an invalid input.

Only the `bump` input block changes. This repo's own configuration in the rest of the
file is untouched, and the pinned `uses:` SHA is left alone since the next `.github`
release re-pins it.

## Types of changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/workflows/release-new-version.yml`** — `bump` options become `auto`,
  `patch`, `feature`, `yearly`, `rc`, with `auto` as the dispatch default and the
  description updated to match
