### PR TITLE
[Process] docs: Align the versioning and release process doc with the current scheme

### DIFF
--- a/src/Valkyrja/VERSIONING_AND_RELEASE_PROCESS.md
+++ b/src/Valkyrja/VERSIONING_AND_RELEASE_PROCESS.md
@@ -2,10 +2,9 @@
 
 ## Introduction
 
-Valkyrja follows [semantic versioning](https://semver.org/). Releases use a
-single integer major version number — `25`, `26`, `27` — rather than the
-traditional `MAJOR.MINOR.PATCH` triple. A new major version is released once per
-year, and each major version is supported for two years from its release date.
+Valkyrja versions are `YY.FEATURE.PATCH`, where `YY` is the two-digit year — so
+`26.4.1` is the fifth feature release of the 2026 line. A new major line opens
+once per year, and each is supported for two years from its release date.
 
 This cadence gives you a predictable upgrade path: you know when a new version
 is coming, how long your current version will be maintained, and what the
@@ -13,15 +12,30 @@ support window looks like before you need to plan a migration.
 
 ## Versioning
 
-Valkyrja uses a three-part version number. Each part signals what kind of
-changes are included in the release.
+Each part of the version signals what kind of changes the release contains.
 
-- **Major** — Breaking changes, new features, and major internal API changes.
-  Released yearly.
-- **Minor** — New features or fixes that are breaking changes but must be
-  implemented before the next major release.
-- **Patch** — Non-breaking fixes, documentation updates, and small atomic
-  changes that don't affect existing functionality.
+- **`YY`** — The year. Opens once a year, and is the only component bumped by
+  hand.
+- **`FEATURE`** — New features, deprecations, and breaking changes.
+- **`PATCH`** — Everything else: fixes, documentation, and small atomic changes
+  that don't affect existing behavior.
+
+Because the year is the major component, it is the only one left to carry
+breaking changes — so **`FEATURE` covers both new features and breaking
+changes**. That is deliberate. Under strict semantic versioning an urgent fix
+that happens to break a public contract cannot ship until someone cuts a major
+release, which means either the fix waits or the break gets hidden in a patch.
+
+Two things keep that manageable for you:
+
+- **Planned removals wait for the year boundary.** An API is deprecated first and
+  removed in the next `YY`, so you get a full line's notice.
+- **Unplanned breaks are always marked.** Any change that breaks a public
+  contract is flagged in the release notes, because the version number alone
+  cannot tell you a `FEATURE` release broke something.
+
+If you pin with a caret (`^26.1`), you will receive feature releases
+automatically — read the release notes before upgrading.
 
 ## Release Schedule
 
@@ -32,8 +46,8 @@ changes are included in the release.
 | 27      | 8.5 – 8.6 | Q1 2027             | Q2 2028         | Q1 2029              |
 | 28      | 8.6+      | Q1 2028             | Q2 2029         | Q1 2030              |
 
-(*) Pre-release version. Version 25 is not supported once version 26 is
-released.
+(*) Version 25 was a pre-release line. It is no longer supported now that
+version 26 has shipped.
 
 ## Support Policy
 
@@ -53,13 +67,14 @@ software in production means known security vulnerabilities will not be patched.
 Each major version in active development has a corresponding branch in the
 repository.
 
-| Branch   | Purpose                                                                                             |
-|:---------|:----------------------------------------------------------------------------------------------------|
-| `master` | Active development for v26. Open for backwards-incompatible changes and major internal API changes. |
-| `25.x`   | The current stable release series. Open for bug fixes only.                                         |
+| Branch   | Purpose                                                                        |
+|:---------|:-------------------------------------------------------------------------------|
+| `26.x`   | The current release line. Where fixes, features, and deprecations land.          |
+| `master` | Preparation for the next year's major. Open for removals and large API changes.  |
 
-When a new major version ships, the previous stable branch moves into
-security-only mode. The `master` branch advances to the next version cycle.
+When a new major version ships, its `YY.x` branch becomes the current line and
+the previous one moves into security-only mode.
 
-Bug fix contributions should target the stable branch (`25.x`). New features and
-breaking changes should target `master`.
+Contributions should target the current `YY.x` branch. Only changes that must
+wait for the next year — chiefly removing something already deprecated — target
+`master`.


### PR DESCRIPTION
# Description

Aligns this repo's user-facing versioning doc with the scheme documented in
[architecture/VERSIONING.md](https://github.com/valkyrjaio/architecture/blob/master/VERSIONING.md).
Sibling PR: valkyrjaio/valkyrja-java#77.

Three things in it were wrong or missing.

**It contradicted itself about the version format.** The introduction said releases use
"a single integer major version number — `25`, `26`, `27` — rather than the traditional
`MAJOR.MINOR.PATCH` triple", while the table immediately below it listed a three-part
version. The scheme is `YY.FEATURE.PATCH`, where the year *is* the major.

**The component descriptions predated the current scheme.** They described a
Major/Minor/Patch split without explaining why the middle component carries both
features and breaking changes, which is the one thing a consumer actually needs to know
before pinning. That reasoning is now stated: the year is the major, so nothing is left
to carry a break, and the alternative is an urgent breaking fix either waiting on a
yearly release or being hidden in a patch. The two mitigations that make it manageable —
deprecate-then-remove at the year boundary, and always marking unplanned breaks — are
spelled out.

**The branch table described a state that no longer exists.** It had `master` as "active
development for v26" and `25.x` as the current stable line. v26 shipped months ago and
lives on `26.x`; `master` is where the next year is prepared. The table and the guidance
below it now say that.

Also updated the pre-release footnote, which still described version 25 as unsupported
"once version 26 is released" as though that were pending.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [x] Documentation improvement

## Changes

- **`VERSIONING_AND_RELEASE_PROCESS.md`**
    - Introduction states the `YY.FEATURE.PATCH` format instead of contradicting the
      table below it
    - Versioning section rewritten around the three components, why `FEATURE` carries
      breaking changes, and what that means when pinning
    - Branch table corrected to `26.x` as the current line and `master` as next-year
      preparation, with contribution guidance to match
    - Pre-release footnote reworded now that v26 has shipped
