### PR TITLE
[Workflow] ci: Adopt the aggregate CI tools workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ 'master', '*.x' ]
+
   pull_request:
     # `edited` is included so a pull request that GitHub auto-retargets — which happens to a stacked
     # pull request the moment its parent merges — re-runs its checks against the new base. A
@@ -23,6 +24,7 @@ permissions:
   contents: read
 
 jobs:
+
   commit-message-check:
     name: Commit Message Check
     if: github.event_name == 'pull_request'
@@ -38,158 +40,24 @@ jobs:
       contents: read
     secrets: inherit
 
-  phparkitect:
-    name: PHPArkitect
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
+  # A check's name is built from every job name down the call chain, so this composes
+  # as `CI / Tools / <Tool> / …`.
+  tools:
+    name: Tools
+    uses: valkyrjaio/.github/.github/workflows/_php-ci-tools.yml@1478335023fb7789f393f598134e00b43907f3f2
     with:
-      tool: 'phparkitect'
-      php-version: '8.4'
-      paths: |
-        ci:
-          - '.github/ci/phparkitect/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/phparkitect/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  phpcodesniffer:
-    name: PHP Code Sniffer
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
-    with:
-      tool: 'phpcodesniffer'
-      php-version: '8.4'
-      paths: |
-        ci:
-          - '.github/ci/phpcodesniffer/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/phpcodesniffer/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  phpcsfixer:
-    name: PHP CS Fixer
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
-    with:
-      tool: 'phpcsfixer'
-      php-version: '8.4'
-      paths: |
-        ci:
-          - '.github/ci/phpcsfixer/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/phpcsfixer/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  phpstan:
-    name: PHPStan
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
-    with:
-      tool: 'phpstan'
       php-version: '8.4'
       additional-directory: '.github/ci/root-and-suggested'
       extensions: 'openswoole'
       composer-options: '--ignore-platform-req=ext-openswoole'
-      paths: |
-        ci:
-          - '.github/ci/phpstan/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/phpstan/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  phpunit:
-    name: PHPUnit
-    uses: valkyrjaio/ci-phpunit-php/.github/workflows/_workflow-call.yml@ca27f8c28932012e8ec6e25c9c949bc410e68b02
-    with:
       php-versions: '["8.4", "8.5", "8.6"]'
       php-version-bleeding-edge: '8.6'
-      additional-directory: '.github/ci/root-and-suggested'
-      extensions: 'mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, pdo_sqlite, pdo_pgsql, pdo_mysql, openswoole, xdebug'
-      composer-options: '--ignore-platform-req=ext-openswoole'
-      paths: |
-        ci:
-          - '.github/ci/phpunit/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/phpunit/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  psalm:
-    name: Psalm
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
-    with:
-      tool: 'psalm'
-      php-version: '8.4'
-      additional-directory: '.github/ci/root-and-suggested'
-      extensions: 'openswoole'
-      composer-options: '--ignore-platform-req=ext-openswoole'
-      run-script: 'psalm-shepherd-with-stats'
-      paths: |
-        ci:
-          - '.github/ci/psalm/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/psalm/**'
-          - '.github/ci/root-and-suggested/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
-    secrets: inherit
-
-  rector:
-    name: Rector
-    uses: valkyrjaio/.github/.github/workflows/_php-ci-tool.yml@ddea291816127b905f6e00006e998f4a6851c1e8
-    with:
-      tool: 'rector'
-      php-version: '8.4'
-      paths: |
-        ci:
-          - '.github/ci/rector/**'
-          - '.github/workflows/ci.yml'
-        files:
-          - '.github/ci/rector/**'
-          - '.github/workflows/ci.yml'
-          - 'bin/valkyrja'
-          - 'functions/**/*.php'
-          - 'src/**/*.php'
-          - 'tests/**/*.php'
-          - 'composer.json'
+      phpunit-extensions: 'mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, pdo_sqlite, pdo_pgsql, pdo_mysql, openswoole, xdebug'
+      psalm-run-script: 'psalm-shepherd-with-stats'
+      source-paths: |
+        bin/valkyrja
+        functions/**/*.php
+        src/**/*.php
+        tests/**/*.php
+        composer.json
     secrets: inherit


### PR DESCRIPTION
# Description

Replaces this repository's 7 per-tool job blocks with a single `Tools` job calling
`valkyrjaio/.github/.github/workflows/_php-ci-tools.yml`.

Pinned to an **unmerged** commit on that workflow's pull request branch, deliberately: it exercises the
three-level chain end to end here before anything merges. GitHub resolves a reusable workflow at the
pinned commit, so this works from a branch. After that pull request merges the pin moves to the merge
commit, and the next `.github` release moves it to the release SHA automatically via the ref sweep.

## Check names

The chain becomes `ci.yml` → `_php-ci-tools.yml` → `_php-ci-tool.yml`, three of the four levels
GitHub permits. A status context is the job-name chain, so each context gains a leading `Tools /`
segment. The UI additionally prefixes the workflow's own `name:` (`CI`), which is why it already
displays a leading `CI /` today — that part is not in the context.

**This is what the pull request is for:** confirming the checks run and pass under the new chain, and
showing the exact context strings the rulesets will need.

`commit-message-check` and `trailing-newline-check` stay top-level, so their contexts are unchanged.

## Derived inputs

`source-paths` replaces the per-tool `paths:` filters — the workflow derives each tool's filter from
these globs plus its own CI directory. The value is the union of what the per-tool jobs used, so no
job's filter narrows; a few broaden.

Everything else is carried over from what the per-tool jobs passed: `php-version`, `additional-directory`, `extensions`, `composer-options`, `php-versions`, `php-version-bleeding-edge`, `phpunit-extensions`, `psalm-run-script`.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`.github/workflows/ci.yml`** — replaced the `phparkitect`, `phpcodesniffer`, `phpcsfixer`, `phpstan`, `phpunit`, `psalm`, `rector` job blocks with one `tools` job named `Tools`.

